### PR TITLE
Step out to the parent folder when typing ../

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,6 +180,10 @@ class FileBrowser {
         if (existingItem !== undefined) {
             this.current.items = this.items;
             this.current.activeItems = [existingItem];
+        } else if (value.endsWith("../")) {
+            this.path.pop();
+            this.file = undefined;
+            this.update();
         } else if (value.endsWith("/")) {
             const path = value.slice(0, -1);
             if (path === "~") {


### PR DESCRIPTION
Helm steps up to the parent folder when you type ../, and this is adding the same to `vscode-file-browser`.

I love the extension. I'm trying to adopt to vscode from emacs, and as a helm user this is great.