### PR TITLE
Implement auto completion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,11 +89,6 @@
 			"integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
 			"dev": true
 		},
-		"@types/user-home": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/user-home/-/user-home-2.0.0.tgz",
-			"integrity": "sha1-F9Sb1zT1gmxvfwasSy71kWL+ZYM="
-		},
 		"@types/vscode": {
 			"version": "1.46.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
@@ -1300,11 +1295,6 @@
 				"word-wrap": "^1.2.3"
 			}
 		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-		},
 		"p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -1627,14 +1617,6 @@
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"user-home": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-			"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-			"requires": {
-				"os-homedir": "^1.0.0"
 			}
 		},
 		"v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,16 @@
                 "key": "ctrl+a",
                 "command": "file-browser.actions",
                 "when": "inFileBrowser"
+            },
+            {
+                "key": "tab",
+                "command": "file-browser.tabNext",
+                "when": "inFileBrowser"
+            },
+            {
+                "key": "shift+tab",
+                "command": "file-browser.tabPrev",
+                "when": "inFileBrowser"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -189,7 +189,10 @@ class FileBrowser {
         }
 
         const existingItem = this.items.find((item) => item.name === value);
-        if (existingItem !== undefined) {
+        if (value === '') {
+            this.current.items = this.items;
+            this.current.activeItems = [];
+        } else if (existingItem !== undefined) {
             this.current.items = this.items;
             this.current.activeItems = [existingItem];
         } else if (value.endsWith("/")) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -267,9 +267,15 @@ class FileBrowser {
         if (this.inActions) {
             return;
         }
-        this.activeItem().ifSome(async (item) => {
+        const item = this.activeItem();
+        item.ifSome(async (item) => {
             this.inActions = true;
             this.path.push(item.name);
+            this.file = undefined;
+            await this.update();
+        });
+        item.ifNone(async () => {
+            this.inActions = true;
             this.file = undefined;
             await this.update();
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ function fileRecordCompare(left: [string, FileType], right: [string, FileType]):
 }
 interface AutoCompletion {
     index: number;
-    items: string[];
+    items: FileItem[];
 }
 
 class FileItem implements QuickPickItem {
@@ -291,7 +291,7 @@ class FileBrowser {
             const step = tabNext ? 1 : -1;
             this.autoCompletion.index = (this.autoCompletion.index + length + step) % length;
         } else {
-            const items = this.items.map(i => i.name).filter(n => n.startsWith(this.current.value));
+            const items = this.items.filter(i => i.name.startsWith(this.current.value));
             this.autoCompletion = {
                 index: tabNext ? 0 : items.length - 1,
                 items,
@@ -299,9 +299,15 @@ class FileBrowser {
         }
 
         const newIndex = this.autoCompletion.index;
-        if (newIndex < this.autoCompletion.items.length) {
+        const length = this.autoCompletion.items.length
+        if (newIndex < length) {
             // This also checks out when items is empty
-            this.current.value = this.autoCompletion.items[newIndex];
+            const item = this.autoCompletion.items[newIndex];
+            this.current.value = item.name;
+            if (length === 1 && item.fileType === FileType.Directory) {
+                this.current.value += Path.sep;
+            }
+
             this.onDidChangeValue(this.current.value, true);
         }
     }


### PR DESCRIPTION
This is a basic implementation of tab completion. It was deliberate to not include the feature to tab into directory directly when there is only one match, because that would prevent people from using the autocomplete and with the `Ctrl+A` menu to open that folder.