### PR TITLE
Restore the menu if input is empty

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,8 +178,12 @@ class FileBrowser {
         if (this.inActions) {
             return;
         }
+
         const existingItem = this.items.find((item) => item.name === value);
-        if (existingItem !== undefined) {
+        if (value === '') {
+            this.current.items = this.items;
+            this.current.activeItems = [];
+        } else if (existingItem !== undefined) {
             this.current.items = this.items;
             this.current.activeItems = [existingItem];
         } else if (value.endsWith("/")) {


### PR DESCRIPTION
This is a bugfix to an empty open new file menu item when a user had entered some text and removed all the text the input box

![image](https://user-images.githubusercontent.com/3455662/87214649-68cf4400-c2e3-11ea-996c-2613d435da15.png)
