### PR TITLE
Handle windows root path element

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ function splitPath(filePath: string): string[] {
     let resolvedPath = Path.resolve(filePath);
     return [Path.parse(resolvedPath).root,
             ...resolvedPath.split(Path.sep).slice(1).filter((it:string) => it)];
-};
+}
 
 function joinPath(pathElems: string[]): string {
     return Path.join(...pathElems);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,12 +30,14 @@ function setContext(state: boolean) {
     vscode.commands.executeCommand("setContext", "inFileBrowser", state);
 }
 
-function splitPath(path: string): string[] {
-    return path.split(Path.sep);
-}
+function splitPath(filePath: string): string[] {
+    let resolvedPath = Path.resolve(filePath);
+    return [Path.parse(resolvedPath).root,
+            ...resolvedPath.split(Path.sep).slice(1).filter((it:string) => it)];
+};
 
-function joinPath(path: string[]): string {
-    return path.join(Path.sep);
+function joinPath(pathElems: string[]): string {
+    return Path.join(...pathElems);
 }
 
 function fileRecordCompare(left: [string, FileType], right: [string, FileType]): -1 | 0 | 1 {


### PR DESCRIPTION
Change  `splitPath` so that on Windows it keeps the backslash in front of the drive letter, since `fs.readDirectory('C:')` will list the contents of cwd instead of `C:\`.

E.g. this:

```js
splitPath('C:\Users\barneydinosaur'); // => ['C:\', 'Users', 'barneydinosaur']
```

Instead of this:

```js
splitPath('C:\Users\barneydinosaur'); // => ['C:', 'Users', 'barneydinosaur']
```

Also changed `joinPath` to use `Path.sep` instead of `"/"` because `C:\Users\barneydinosaur` is prettier than `C:\Users/barneydinosaur`.

The only behavior that changed on *nix is that now holding left until the path is cleared out leaves you with `"/"` instead of `""`.