### PR TITLE
Prevent adding "invisible" path elements

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,15 @@ function joinPath(path: string[]): string {
     return path.join(Path.sep);
 }
 
+function endsWithPathSep(value: string): boolean {
+    return value.endsWith("/") || value.endsWith(Path.sep);
+}
+
+const regExpTrimPathSeps = new RegExp(`^(${Path.sep}|/)+|(${Path.sep}|/)+$`, 'g');
+function trimPathSeps(value: string): string {
+    return value.replace(regExpTrimPathSeps, '');
+}
+
 function fileRecordCompare(left: [string, FileType], right: [string, FileType]): -1 | 0 | 1 {
     const [leftName, leftDir] = [
         left[0].toLowerCase(),
@@ -195,8 +204,8 @@ class FileBrowser {
         } else if (existingItem !== undefined) {
             this.current.items = this.items;
             this.current.activeItems = [existingItem];
-        } else if (value.endsWith("/")) {
-            const path = value.slice(0, -1);
+        } else if (endsWithPathSep(value)) {
+            const path = trimPathSeps(value);
             if (path === "~") {
                 this.path = splitPath(OS.homedir());
             } else if (path === "..") {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,9 +42,14 @@ function endsWithPathSep(value: string): boolean {
     return value.endsWith("/") || value.endsWith(Path.sep);
 }
 
-const regExpTrimPathSeps = new RegExp(`^(${Path.sep}|/)+|(${Path.sep}|/)+$`, 'g');
-function trimPathSeps(value: string): string {
-    return value.replace(regExpTrimPathSeps, '');
+const escapedPathSep = Path.sep.replace('\\', '\\\\');
+const regExpTrimPathSeps = new RegExp(`^(${escapedPathSep}|/)+|(${escapedPathSep}|/)+$`, 'g');
+const regExpCollapsePathSeps = new RegExp(`[${escapedPathSep}/]+`, 'g');
+
+function normalizePathSeps(value: string): string {
+    return value
+        .replace(regExpTrimPathSeps, '')
+        .replace(regExpCollapsePathSeps, Path.sep);
 }
 
 function fileRecordCompare(left: [string, FileType], right: [string, FileType]): -1 | 0 | 1 {
@@ -205,7 +210,7 @@ class FileBrowser {
             this.current.items = this.items;
             this.current.activeItems = [existingItem];
         } else if (endsWithPathSep(value)) {
-            const path = trimPathSeps(value);
+            const path = normalizePathSeps(value);
             if (path === "~") {
                 this.path = splitPath(OS.homedir());
             } else if (path === "..") {


### PR DESCRIPTION
Trim ends and collapse path separators in `onDidChangeValue` so that it doesn't create a bunch of empty elements in the path array.

This would happen if you held down `/` or pasted in something with `///\/\\a//\\silly\/combination/of////slashes`.

Also change `onDidChangeValue` to accept either `/` or `Path.sep` as a terminating character.