### PR TITLE
Jump to file system root if input value is /

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,8 @@ import { Rules } from "./filter";
 import { FileItem, fileRecordCompare } from "./fileitem";
 import { action, Action } from "./action";
 
+const fileSystemRootPath = OSPath.parse(process.cwd()).root;
+
 export enum ConfigItem {
     RemoveIgnoredFiles = "removeIgnoredFiles",
     HideDotfiles = "hideDotfiles",
@@ -155,6 +157,8 @@ class FileBrowser {
         } else if (existingItem !== undefined) {
             this.current.items = this.items;
             this.current.activeItems = [existingItem];
+        } else if (value === fileSystemRootPath) {
+            this.stepIntoFolder(Path.fromFilePath(fileSystemRootPath));
         } else {
             endsWithPathSeparator(value).match(
                 (path) => {


### PR DESCRIPTION
If the user enters the path to their file system root, switch straight to that directory.

I don't have access to a Windows machine to test this but I tried to make it platform independent.

I believe Windows users will need to enter `C:\` to jump to the root which seems a bit cumbersome to me. It could easilybe changed so that entering the path separator jumps to root instead. That way, Windows users could enter `\`. Maybe a Windows user can change this later.

Fixes #16 