### PR TITLE
[Partial fix] requires too many keystrokes for the standard use-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the "file-browser" extension will be documented in this f
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this
 file.
 
+## [0.2.12]
+
+### CHANGED
+
+-   Currently the extension is activated when user calls the file browser open command for the first time. To make it responsive, activated it after the StartupFinished. This does not add delay to the vscode startup.
+-    Removed the 'open as new file' inline command. This was annoying and was forcing the user to type the full name of file/folder.
+-        Moved the 'open as new file' inline command to under the action menu.
+
 ## [0.2.10]
 
 ### CHANGED

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "bodil",
     "displayName": "File Browser",
     "description": "A nicer alternative to the file open dialog.",
-    "version": "0.2.10",
+    "version": "0.2.12",
     "license": "LGPL-3.0+",
     "author": {
         "name": "Bodil Stokke",
@@ -25,6 +25,7 @@
         "Other"
     ],
     "activationEvents": [
+        "onStartupFinished",
         "onCommand:file-browser.open"
     ],
     "main": "./out/extension.js",

--- a/src/action.ts
+++ b/src/action.ts
@@ -9,10 +9,10 @@ export enum Action {
     OpenFolderInNewWindow,
 }
 
-export function action(label: string, action: Action) {
+export function action(label: string, action: Action, name: string = "") {
     return {
         label,
-        name: "",
+        name,
         action,
         alwaysShow: true,
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { Uri, QuickPickItem, FileType, QuickInputButton, ThemeIcon, ViewColumn } from "vscode";
+import { Uri, FileType, QuickInputButton, ThemeIcon, ViewColumn } from "vscode";
 import * as OS from "os";
 import * as OSPath from "path";
 
@@ -92,15 +92,17 @@ class FileBrowser {
     async update() {
         this.current.enabled = false;
         this.current.title = this.path.fsPath;
-        this.current.value = "";
+        // this.current.value = "";
 
         const stat = (await Result.try(vscode.workspace.fs.stat(this.path.uri))).unwrap();
         if (stat && this.inActions && (stat.type & FileType.File) === FileType.File) {
+            const selectedFile = new Path(this.path.uri).pop().unwrap();
             this.items = [
-                action("$(file) Open this file", Action.OpenFile),
-                action("$(split-horizontal) Open this file to the side", Action.OpenFileBeside),
-                action("$(edit) Rename this file", Action.RenameFile),
-                action("$(trash) Delete this file", Action.DeleteFile),
+                action(`$(new-file) Create file: ${this.current.value}`, Action.NewFile, this.current.value),
+                action(`$(file) Open file '${selectedFile}'`, Action.OpenFile),
+                action(`$(split-horizontal) Open file '${selectedFile}' to the side`, Action.OpenFileBeside),
+                action(`$(edit) Rename file '${selectedFile}'`, Action.RenameFile),
+                action(`$(trash) Delete file '${selectedFile}'`, Action.DeleteFile),
             ];
             this.current.items = this.items;
         } else if (
@@ -166,17 +168,7 @@ class FileBrowser {
                         this.stepIntoFolder(this.path.append(path));
                     }
                 },
-                () => {
-                    const newItem = {
-                        label: `$(new-file) ${value}`,
-                        name: value,
-                        description: "Open as new file",
-                        alwaysShow: true,
-                        action: Action.NewFile,
-                    };
-                    this.current.items = [newItem, ...this.items];
-                    this.current.activeItems = [newItem];
-                }
+                () => { }
             );
         }
     }


### PR DESCRIPTION
Fixes #19

  * moved 'open as new file' to action menu.
  * The extension will be loaded as soon as VsCode starts up - feels more responsive.