### PR TITLE
Add command to rename currently opened file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ file.
 
 ## [0.2.11]
 
+## ADDED
+
+- You can now use `file-browser.rename` command to rename currently opened file directly
+
 ### CHANGED
 
 -   While loading the file list, show a 'busy' animation untill the files are ready to be shown.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:file-browser.open"
+        "onCommand:file-browser.open",
+        "onCommand:file-browser.rename"
     ],
     "main": "./out/extension.js",
     "extensionKind": [
@@ -74,6 +75,10 @@
             {
                 "command": "file-browser.open",
                 "title": "File Browser: Open"
+            },
+            {
+                "command": "file-browser.rename",
+                "title": "File Browser: Rename"
             },
             {
                 "command": "file-browser.stepIn",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -309,6 +309,42 @@ class FileBrowser {
             .then((doc) => vscode.window.showTextDocument(doc, column));
     }
 
+    async rename() {
+        const uri = this.path.uri;
+        const stat = await vscode.workspace.fs.stat(uri);
+        const isDir = (stat.type & FileType.Directory) === FileType.Directory;
+        const fileName = this.path.pop().unwrapOrElse(() => {
+            throw new Error("Can't rename an empty file name!");
+        });
+        const fileType = isDir ? "folder" : "file";
+        const workspaceFolder = this.path.getWorkspaceFolder().map((wsf) => wsf.uri);
+        const relPath = workspaceFolder
+            .andThen((workspaceFolder) => new Path(uri).relativeTo(workspaceFolder))
+            .unwrapOr(fileName);
+        const extension = OSPath.extname(relPath);
+        const startSelection = relPath.length - fileName.length;
+        const endSelection = startSelection + (fileName.length - extension.length);
+        const result = await vscode.window.showInputBox({
+            prompt: `Enter the new ${fileType} name`,
+            value: relPath,
+            valueSelection: [startSelection, endSelection],
+        });
+        this.file = Some(fileName);
+        if (result !== undefined) {
+            const newUri = workspaceFolder.match(
+                (workspaceFolder) => Uri.joinPath(workspaceFolder, result),
+                () => Uri.joinPath(this.path.uri, result)
+            );
+            if ((await Result.try(vscode.workspace.fs.rename(uri, newUri))).isOk()) {
+                this.file = Some(OSPath.basename(result));
+            } else {
+                vscode.window.showErrorMessage(
+                    `Failed to rename ${fileType} "${fileName}"`
+                );
+            }
+        }
+    }
+
     async runAction(item: FileItem) {
         switch (item.action) {
             case Action.NewFolder: {
@@ -340,39 +376,7 @@ class FileBrowser {
             case Action.RenameFile: {
                 this.keepAlive = true;
                 this.hide();
-                const uri = this.path.uri;
-                const stat = await vscode.workspace.fs.stat(uri);
-                const isDir = (stat.type & FileType.Directory) === FileType.Directory;
-                const fileName = this.path.pop().unwrapOrElse(() => {
-                    throw new Error("Can't rename an empty file name!");
-                });
-                const fileType = isDir ? "folder" : "file";
-                const workspaceFolder = this.path.getWorkspaceFolder().map((wsf) => wsf.uri);
-                const relPath = workspaceFolder
-                    .andThen((workspaceFolder) => new Path(uri).relativeTo(workspaceFolder))
-                    .unwrapOr(fileName);
-                const extension = OSPath.extname(relPath);
-                const startSelection = relPath.length - fileName.length;
-                const endSelection = startSelection + (fileName.length - extension.length);
-                const result = await vscode.window.showInputBox({
-                    prompt: `Enter the new ${fileType} name`,
-                    value: relPath,
-                    valueSelection: [startSelection, endSelection],
-                });
-                this.file = Some(fileName);
-                if (result !== undefined) {
-                    const newUri = workspaceFolder.match(
-                        (workspaceFolder) => Uri.joinPath(workspaceFolder, result),
-                        () => Uri.joinPath(this.path.uri, result)
-                    );
-                    if ((await Result.try(vscode.workspace.fs.rename(uri, newUri))).isOk()) {
-                        this.file = Some(OSPath.basename(result));
-                    } else {
-                        vscode.window.showErrorMessage(
-                            `Failed to rename ${fileType} "${fileName}"`
-                        );
-                    }
-                }
+                await this.rename();
                 this.show();
                 this.keepAlive = false;
                 this.inActions = false;
@@ -438,6 +442,19 @@ export function activate(context: vscode.ExtensionContext) {
             active = Some(new FileBrowser(path, file));
             setContext(true);
         })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand("file-browser.rename", () =>
+            active.orElse(() => {
+                const document = vscode.window.activeTextEditor?.document;
+                let workspaceFolder =
+                    vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0];
+                let path = new Path(document?.uri || workspaceFolder?.uri || Uri.file(OS.homedir()));
+                active = Some(new FileBrowser(path, None));
+                setContext(true);
+                return active;
+            }).ifSome((active) => active.rename())
+        )
     );
 
     context.subscriptions.push(


### PR DESCRIPTION
The implementation of rename in file browser, can be used to replace the built-in rename command. Currently, this extension doesn't provide a command to directly use its rename command.

This PR exacts the rename function so
- a user can bind a shortcut to use file browser to rename the currently opened file
- an external extension like VSpaceCode to bind this directly to replace the built-in rename command