### PR TITLE
Comment out "this.current.enabled = false" to fix hindered navigation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,9 @@ class FileBrowser {
     }
 
     async update() {
-        this.current.enabled = false;
+        // FIXME: temporary and UGLY fix of https://github.com/bodil/vscode-file-browser/issues/35.
+        // Brought in from here https://github.com/atariq11700/vscode-file-browser/commit/a2525d01f262f17dac2c478e56640c9ce1f65713.
+        // this.current.enabled = false;
         this.current.show();
         this.current.busy = true;
         this.current.title = this.path.fsPath;


### PR DESCRIPTION
Thank you really a lot for all your work Bodil, I hope this will help 🙏 

This is really just a workaround brought in form [here](https://github.com/atariq11700/vscode-file-browser/commit/a2525d01f262f17dac2c478e56640c9ce1f65713) to fix https://github.com/bodil/vscode-file-browser/issues/35.

JFYI [the fork from where the fix comes from](https://github.com/atariq11700/vscode-file-browser) doesn't seem to work due to the following error:
```
Error: dlopen(~/.vscode-insiders/extensions/atariq11700.file-browser-fixed-0.2.14/node_modules/drivelist/build/Release/drivelist.node, 0x0001))
```

P.S: contribution done in the context of  [![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/) 😄 