### PR TITLE
Open file in Horizontal Split functionality

### DIFF
--- a/src/fileitem.ts
+++ b/src/fileitem.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
-import { QuickPickItem, FileType } from "vscode";
+import { FileType, QuickPickItem } from "vscode";
 import { Action } from "./action";
-import { config, ConfigItem } from "./extension";
+import { ConfigItem, config } from "./extension";
 
 export class FileItem implements QuickPickItem {
     name: string;
@@ -11,6 +11,7 @@ export class FileItem implements QuickPickItem {
     description?: string;
     fileType?: FileType;
     action?: Action;
+    buttons?: vscode.QuickInputButton[];
 
     constructor(record: [string, FileType]) {
         const [name, fileType] = record;
@@ -28,6 +29,12 @@ export class FileItem implements QuickPickItem {
                 this.label = `$(file-symlink-file) ${name}`;
             default:
                 this.label = `$(file) ${name}`;
+                this.buttons = [
+                    {
+                        iconPath: new vscode.ThemeIcon('split-horizontal'),
+                        tooltip: 'Open in Horizontal split',
+                    },
+                ];
                 break;
         }
     }


### PR DESCRIPTION
This is how it looks:
<img width="960" alt="image" src="https://github.com/bodil/vscode-file-browser/assets/1500881/9be29580-11ea-4881-a9a5-656966802b7d">


The icon appears on the active item.

Changes:
- Added the button for the quick quick item entry
- Added a command to trigger this behaviour through a keybinding

Let me know if you want me change something. Happy holidays

Also created a PR for the fork: https://github.com/jeffgran/vscode-quick-file-browser/pull/2