### PR TITLE
Feat: add stat handler for multiple uri schemas and notebook document api

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,16 +1,16 @@
 {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 6,
-        "sourceType": "module"
-    },
-    "plugins": ["@typescript-eslint"],
-    "rules": {
-        "@typescript-eslint/semi": "warn",
-        "curly": "warn",
-        "eqeqeq": "warn",
-        "no-throw-literal": "warn",
-        "semi": "off"
-    }
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/semi": "off",
+    "curly": "warn",
+    "eqeqeq": "warn",
+    "no-throw-literal": "warn",
+    "semi": "off"
+  }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,5 @@
 {
-	// See http://go.microsoft.com/fwlink/?LinkId=827846
-	// for the documentation about the extensions.json format
-	"recommendations": [
-		"dbaeumer.vscode-eslint"
-	]
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,34 +3,28 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
-			],
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
-			"preLaunchTask": "${defaultBuildTask}"
-		},
-		{
-			"name": "Extension Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
-			],
-			"outFiles": [
-				"${workspaceFolder}/out/test/**/*.js"
-			],
-			"preLaunchTask": "${defaultBuildTask}"
-		}
-	]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "${defaultBuildTask}"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+      ],
+      "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+      "preLaunchTask": "${defaultBuildTask}"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,31 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
-    },
-    "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
-    },
-    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off",
-    "typescript.tsdk": "node_modules/typescript/lib",
-    "file-browser.isActive": true
+  "files.exclude": {
+    "out": false // set this to true to hide the "out" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "out": true // set this to false to include "out" folder in search results
+  },
+  // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+  "typescript.tsc.autoDetect": "off",
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "file-browser.isActive": true,
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "prettier.trailingComma": "all",
+    "prettier.singleQuote": false,
+    "prettier.semi": false
+  },
+  "[markdown]": {
+    "editor.formatOnSave": true
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,20 +1,20 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": "$tsc-watch",
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		}
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,120 +5,130 @@ All notable changes to the "file-browser" extension will be documented in this f
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this
 file.
 
+## [0.2.12]
+
+### FIXED
+
+- When you were located in an opened Jupyter Notebook the `File Browser: Open` didn't load. Now it does.
+
+## ADDED
+
+- Now when you open a Jupyter Notebook it is rendered with the proper format and not as json.
+
 ## [0.2.11]
 
 ### FIXED
 
--   Fixed a VSCode regression bug where the file browser would lose focus when navigating up and
-    down the directory tree. (#35, #37)
+- Fixed a VSCode regression bug where the file browser would lose focus when navigating up and
+  down the directory tree. (#35, #37)
 
 ## ADDED
 
--   You can now use `file-browser.rename` command to rename currently opened file directly. (#27)
+- You can now use `file-browser.rename` command to rename currently opened file directly. (#27)
 
 ### CHANGED
 
--   While loading the file list, show a 'busy' animation untill the files are ready to be shown.
-    (#23)
+- While loading the file list, show a 'busy' animation untill the files are ready to be shown.
+  (#23)
 
 ## [0.2.10]
 
 ### CHANGED
 
--   The `file-browser.hideIgnoredFiles` setting is now off by default, as it can have a noticeable
-    performance impact on certain filesystems. (#14)
+- The `file-browser.hideIgnoredFiles` setting is now off by default, as it can have a noticeable
+  performance impact on certain filesystems. (#14)
 
 ## [0.2.9]
 
 ### ADDED
 
--   You can now toggle the labelling of `.gitignore`d files on or off in the settings.
+- You can now toggle the labelling of `.gitignore`d files on or off in the settings.
 
 ## [0.2.8]
 
 ### ADDED
 
--   You now have the option to hide files matched by `.gitignore` and similar in addition to
-    dotfiles when matching, or to remove these from the directory listing entirely.
--   The extension can now run as a local extension when using a remote, so that it will still be
-    available if you have it installed locally but not on the remote. It will prefer the remote
-    installation if one is available, because the local version will render paths the way the local
-    OS thinks they should look, rather than how the remote OS would render them.
+- You now have the option to hide files matched by `.gitignore` and similar in addition to
+  dotfiles when matching, or to remove these from the directory listing entirely.
+- The extension can now run as a local extension when using a remote, so that it will still be
+  available if you have it installed locally but not on the remote. It will prefer the remote
+  installation if one is available, because the local version will render paths the way the local
+  OS thinks they should look, rather than how the remote OS would render them.
 
 ### FIXED
 
--   Paths are now stored as `vscode.Uri` internally, and using `Uri` for path manipulation as much
-    as possible, which should lead to more robust cross platform path handling in general, and when
-    dealing with local files open on a remote in particular.
--   You can now use the left and right arrow keys normally in the input box when renaming a file,
-    where it would previously lead to unexpectedly reopening the file browser.
+- Paths are now stored as `vscode.Uri` internally, and using `Uri` for path manipulation as much
+  as possible, which should lead to more robust cross platform path handling in general, and when
+  dealing with local files open on a remote in particular.
+- You can now use the left and right arrow keys normally in the input box when renaming a file,
+  where it would previously lead to unexpectedly reopening the file browser.
 
 ## [0.2.7]
 
 ### ADDED
 
--   You can now optionally open a folder in a new window instead of replacing the current project
-    folder. (#11)
+- You can now optionally open a folder in a new window instead of replacing the current project
+  folder. (#11)
 
 ## [0.2.6]
 
 ### FIXED
 
--   Some path parsing bugs fixed, most notably that Windows root paths will no longer confuse the
-    extension. (#7, #8)
+- Some path parsing bugs fixed, most notably that Windows root paths will no longer confuse the
+  extension. (#7, #8)
 
 ## [0.2.5]
 
 ### ADDED
 
--   You can now start typing a file name and hit `Tab` to autocomplete it. If there are multiple
-    matches, you can cycle through them with `Tab` and `Shift+Tab`. (#3)
--   If you're in an empty folder, `Ctrl+A` now works to open the folder actions. (#3)
+- You can now start typing a file name and hit `Tab` to autocomplete it. If there are multiple
+  matches, you can cycle through them with `Tab` and `Shift+Tab`. (#3)
+- If you're in an empty folder, `Ctrl+A` now works to open the folder actions. (#3)
 
 ## [0.2.4]
 
 ### ADDED
 
--   There is now an option to open the folder as a workspace if you hit `Ctrl+A` on a folder.
+- There is now an option to open the folder as a workspace if you hit `Ctrl+A` on a folder.
 
 ## [0.2.3]
 
 ### ADDED
 
--   You can now type `../` to step up to the parent directory. (#1)
+- You can now type `../` to step up to the parent directory. (#1)
 
 ### FIXED
 
--   Typing a single `/` will now be quietly ignored instead of causing unexpected behaviour.
+- Typing a single `/` will now be quietly ignored instead of causing unexpected behaviour.
 
 ## [0.2.1]
 
 ### ADDED
 
--   You can now bring up rename/delete actions on a folder with the "Ctrl+A" key or by using the new
-    action menu button.
--   When you rename or delete a file or folder, the file browser now stays open.
+- You can now bring up rename/delete actions on a folder with the "Ctrl+A" key or by using the new
+  action menu button.
+- When you rename or delete a file or folder, the file browser now stays open.
 
 ### FIXED
 
--   Stepping into a folder that doesn't currently exist now correctly displays the "Create folder"
-    action.
+- Stepping into a folder that doesn't currently exist now correctly displays the "Create folder"
+  action.
 
 ## [0.2.0]
 
 ### ADDED
 
--   You can now step into a file to access file operations such as rename and delete.
+- You can now step into a file to access file operations such as rename and delete.
 
 ## [0.1.1] - 2020-06-22
 
 ### FIXED
 
--   Removed the `isActive` setting in favour of `setContext`. Keybindings for the file browser
-    should now use `"when": "inFileBrowser"`.
--   Open at a sensible path (either the workspace root or the user's home directory, in order of
-    preference) if launched from an untitled document.
+- Removed the `isActive` setting in favour of `setContext`. Keybindings for the file browser
+  should now use `"when": "inFileBrowser"`.
+- Open at a sensible path (either the workspace root or the user's home directory, in order of
+  preference) if launched from an untitled document.
 
 ## [0.1.0] - 2020-06-21
 
--   Initial release
+- Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
     "name": "file-browser",
     "version": "0.2.11",
-    "lockfileVersion": 2,
+    "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
@@ -29,16 +29,40 @@
                 "vscode": "^1.73.1"
             }
         },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+            "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-            "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.4.0",
-                "globals": "^13.15.0",
+                "espree": "^9.6.0",
+                "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -52,14 +76,23 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@eslint/js": {
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.7",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-            "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
             "engines": {
@@ -80,9 +113,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "dev": true
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -140,54 +173,58 @@
             }
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
         },
         "node_modules/@types/minimatch": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
             "dev": true
         },
         "node_modules/@types/mocha": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.0.tgz",
-            "integrity": "sha512-rADY+HtTOA52l9VZWtgQfn4p+UDVM2eDVkMZT1I6syp0YKxW2F9v+0pbRZLsvskhQv/vMb6ZfCay81GHbz5SHg==",
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+            "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.11.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-            "dev": true
+            "version": "18.19.33",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
+            "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/semver": {
-            "version": "7.3.13",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.73.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
-            "integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
+            "version": "1.89.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.89.0.tgz",
+            "integrity": "sha512-TMfGKLSVxfGfoO8JfIE/neZqv7QLwS4nwPwL/NwMvxtAY2230H2I4Z5xx6836pmJvMAzqooRQ4pmLm7RUicP3A==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
-            "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+            "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.43.0",
-                "@typescript-eslint/type-utils": "5.43.0",
-                "@typescript-eslint/utils": "5.43.0",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/type-utils": "5.62.0",
+                "@typescript-eslint/utils": "5.62.0",
                 "debug": "^4.3.4",
+                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             },
@@ -209,14 +246,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
-            "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+            "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.43.0",
-                "@typescript-eslint/types": "5.43.0",
-                "@typescript-eslint/typescript-estree": "5.43.0",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -236,13 +273,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
-            "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+            "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.43.0",
-                "@typescript-eslint/visitor-keys": "5.43.0"
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -253,13 +290,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
-            "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+            "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.43.0",
-                "@typescript-eslint/utils": "5.43.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
+                "@typescript-eslint/utils": "5.62.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -280,9 +317,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
-            "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+            "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -293,13 +330,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
-            "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+            "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.43.0",
-                "@typescript-eslint/visitor-keys": "5.43.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -320,18 +357,18 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
-            "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+            "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
             "dev": true,
             "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.43.0",
-                "@typescript-eslint/types": "5.43.0",
-                "@typescript-eslint/typescript-estree": "5.43.0",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
                 "semver": "^7.3.7"
             },
             "engines": {
@@ -346,12 +383,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
-            "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+            "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.43.0",
+                "@typescript-eslint/types": "5.62.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -362,79 +399,31 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
+        },
         "node_modules/@vscode/test-electron": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.0.tgz",
-            "integrity": "sha512-xk2xrOTMG75/hxO8OVVZ+GErv9gmdZwOD8rEHV3ty3n1Joav2yFcfrmqD6Ukref27U13LEL8gVvSHzauGAK5nQ==",
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.9.tgz",
+            "integrity": "sha512-z3eiChaCQXMqBnk2aHHSEkobmC2VRalFQN0ApOAtydL172zXGxTwGrRtviT5HnUB+Q+G3vtEYFtuQkYqBzYgMA==",
             "dev": true,
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
                 "https-proxy-agent": "^5.0.0",
-                "rimraf": "^3.0.2",
-                "unzipper": "^0.10.11"
+                "jszip": "^3.10.1",
+                "semver": "^7.5.2"
             },
             "engines": {
-                "node": ">=8.9.3"
-            }
-        },
-        "node_modules/@vscode/test-electron/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/@vscode/test-electron/node_modules/http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-            "dev": true,
-            "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@vscode/test-electron/node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": ">=16"
             }
         },
         "node_modules/acorn": {
-            "version": "8.8.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -450,6 +439,18 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/ajv": {
@@ -486,6 +487,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ansi-sequence-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+            "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+            "dev": true
+        },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -502,9 +509,9 @@
             }
         },
         "node_modules/anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
@@ -535,42 +542,17 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
-        "node_modules/big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/binary": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "dev": true,
-            "dependencies": {
-                "buffers": "~0.1.1",
-                "chainsaw": "~0.1.0"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/bluebird": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-            "dev": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -600,24 +582,6 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
-        "node_modules/buffer-indexof-polyfill": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/buffers": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.2.0"
-            }
-        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -637,18 +601,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/chainsaw": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "dev": true,
-            "dependencies": {
-                "traverse": ">=0.3.0 <0.4"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/chalk": {
@@ -829,15 +781,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
-            "dependencies": {
-                "readable-stream": "^2.0.2"
-            }
-        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -845,9 +788,9 @@
             "dev": true
         },
         "node_modules/escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -866,49 +809,48 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-            "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.11.6",
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
-                "ajv": "^6.10.0",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.4.0",
-                "esquery": "^1.4.0",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
+                "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
-                "globals": "^13.15.0",
-                "grapheme-splitter": "^1.0.4",
+                "globals": "^13.19.0",
+                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "is-path-inside": "^3.0.3",
-                "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
+                "optionator": "^0.9.3",
                 "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
             },
             "bin": {
@@ -934,46 +876,22 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "dependencies": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "engines": {
-                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=5"
-            }
-        },
-        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -981,6 +899,9 @@
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/estraverse": {
@@ -993,14 +914,14 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.8.0",
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1010,9 +931,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
             "dev": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -1076,9 +997,9 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -1116,9 +1037,9 @@
             "dev": true
         },
         "node_modules/fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -1174,49 +1095,35 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "dependencies": {
-                "flatted": "^3.1.0",
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.3",
                 "rimraf": "^3.0.2"
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
-        "node_modules/flat-cache/node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/flatted": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
             "dev": true
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
         "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
             "optional": true,
@@ -1225,21 +1132,6 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/fstream": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-            },
-            "engines": {
-                "node": ">=0.6"
             }
         },
         "node_modules/get-caller-file": {
@@ -1284,9 +1176,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.18.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-            "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -1318,16 +1210,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-            "dev": true
-        },
-        "node_modules/grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
         "node_modules/has-flag": {
@@ -1348,13 +1234,46 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+            "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
             "engines": {
                 "node": ">= 4"
             }
+        },
+        "node_modules/immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "dev": true
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -1384,7 +1303,7 @@
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
@@ -1412,7 +1331,7 @@
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -1490,12 +1409,6 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
-        "node_modules/js-sdsl": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-            "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-            "dev": true
-        },
         "node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1507,6 +1420,12 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -1521,10 +1440,31 @@
             "dev": true
         },
         "node_modules/jsonc-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+            "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
             "dev": true
+        },
+        "node_modules/jszip": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+            "dev": true,
+            "dependencies": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "^1.0.5"
+            }
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
         },
         "node_modules/levn": {
             "version": "0.4.1",
@@ -1539,11 +1479,14 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/listenercount": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-            "dev": true
+        "node_modules/lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "dev": true,
+            "dependencies": {
+                "immediate": "~3.0.5"
+            }
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
@@ -1582,18 +1525,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/lunr": {
             "version": "2.3.9",
             "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -1601,9 +1532,9 @@
             "dev": true
         },
         "node_modules/marked": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.2.tgz",
-            "integrity": "sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
             "dev": true,
             "bin": {
                 "marked": "bin/marked.js"
@@ -1646,31 +1577,10 @@
                 "node": "*"
             }
         },
-        "node_modules/minimist": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
         "node_modules/mocha": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.1.0.tgz",
-            "integrity": "sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
+            "integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
             "dev": true,
             "dependencies": {
                 "ansi-colors": "4.1.1",
@@ -1680,13 +1590,12 @@
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.2.0",
+                "glob": "8.1.0",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
                 "minimatch": "5.0.1",
                 "ms": "2.1.3",
-                "nanoid": "3.3.3",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
@@ -1701,42 +1610,34 @@
             },
             "engines": {
                 "node": ">= 14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mochajs"
+            }
+        },
+        "node_modules/mocha/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/mocha/node_modules/glob": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
             },
             "engines": {
-                "node": "*"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/mocha/node_modules/minimatch": {
@@ -1749,15 +1650,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/mocha/node_modules/ms": {
@@ -1787,18 +1679,6 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
-        "node_modules/nanoid": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-            "dev": true,
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1823,16 +1703,16 @@
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
@@ -1840,7 +1720,7 @@
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
                 "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "word-wrap": "^1.2.5"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -1876,6 +1756,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -1900,7 +1786,7 @@
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -1952,9 +1838,9 @@
             "dev": true
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -1990,9 +1876,9 @@
             }
         },
         "node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -2004,12 +1890,6 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
-        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2020,18 +1900,6 @@
             },
             "engines": {
                 "node": ">=8.10.0"
-            }
-        },
-        "node_modules/regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
             }
         },
         "node_modules/require-directory": {
@@ -2063,15 +1931,18 @@
             }
         },
         "node_modules/rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
             "bin": {
                 "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/run-parallel": {
@@ -2098,33 +1969,16 @@
             }
         },
         "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
             "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -2169,14 +2023,15 @@
             }
         },
         "node_modules/shiki": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-            "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+            "version": "0.14.7",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+            "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
             "dev": true,
             "dependencies": {
-                "jsonc-parser": "^3.0.0",
-                "vscode-oniguruma": "^1.6.1",
-                "vscode-textmate": "^6.0.0"
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
             }
         },
         "node_modules/slash": {
@@ -2196,12 +2051,6 @@
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
-        },
-        "node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
         },
         "node_modules/string-width": {
             "version": "4.2.3",
@@ -2271,15 +2120,6 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/traverse": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -2326,15 +2166,15 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.23.21",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.21.tgz",
-            "integrity": "sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==",
+            "version": "0.23.28",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+            "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
             "dev": true,
             "dependencies": {
                 "lunr": "^2.3.9",
-                "marked": "^4.0.19",
-                "minimatch": "^5.1.0",
-                "shiki": "^0.11.1"
+                "marked": "^4.2.12",
+                "minimatch": "^7.1.3",
+                "shiki": "^0.14.1"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
@@ -2343,7 +2183,7 @@
                 "node": ">= 14.14"
             },
             "peerDependencies": {
-                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
             }
         },
         "node_modules/typedoc/node_modules/brace-expansion": {
@@ -2356,21 +2196,24 @@
             }
         },
         "node_modules/typedoc/node_modules/minimatch": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-            "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+            "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-            "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -2380,23 +2223,11 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "dev": true,
-            "dependencies": {
-                "big-integer": "^1.6.17",
-                "binary": "~0.3.0",
-                "bluebird": "~3.4.1",
-                "buffer-indexof-polyfill": "~1.0.0",
-                "duplexer2": "~0.1.4",
-                "fstream": "^1.0.12",
-                "graceful-fs": "^4.2.2",
-                "listenercount": "~1.0.1",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "~1.0.4"
-            }
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -2414,15 +2245,15 @@
             "dev": true
         },
         "node_modules/vscode-oniguruma": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
             "dev": true
         },
         "node_modules/vscode-textmate": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-            "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
             "dev": true
         },
         "node_modules/which": {
@@ -2441,9 +2272,9 @@
             }
         },
         "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -2475,7 +2306,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
         },
         "node_modules/y18n": {
@@ -2486,12 +2317,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
         },
         "node_modules/yargs": {
             "version": "16.2.0",
@@ -2546,1846 +2371,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        }
-    },
-    "dependencies": {
-        "@eslint/eslintrc": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-            "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
-            "dev": true,
-            "requires": {
-                "ajv": "^6.12.4",
-                "debug": "^4.3.2",
-                "espree": "^9.4.0",
-                "globals": "^13.15.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
-                "minimatch": "^3.1.2",
-                "strip-json-comments": "^3.1.1"
-            }
-        },
-        "@humanwhocodes/config-array": {
-            "version": "0.11.7",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-            "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
-            "dev": true,
-            "requires": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.5"
-            }
-        },
-        "@humanwhocodes/module-importer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "dev": true
-        },
-        "@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true
-        },
-        "@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            }
-        },
-        "@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true
-        },
-        "@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            }
-        },
-        "@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-            "dev": true
-        },
-        "@types/glob": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-            "dev": true,
-            "requires": {
-                "@types/minimatch": "*",
-                "@types/node": "*"
-            }
-        },
-        "@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-            "dev": true
-        },
-        "@types/minimatch": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-            "dev": true
-        },
-        "@types/mocha": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.0.tgz",
-            "integrity": "sha512-rADY+HtTOA52l9VZWtgQfn4p+UDVM2eDVkMZT1I6syp0YKxW2F9v+0pbRZLsvskhQv/vMb6ZfCay81GHbz5SHg==",
-            "dev": true
-        },
-        "@types/node": {
-            "version": "18.11.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-            "dev": true
-        },
-        "@types/semver": {
-            "version": "7.3.13",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
-            "dev": true
-        },
-        "@types/vscode": {
-            "version": "1.73.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
-            "integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
-            "dev": true
-        },
-        "@typescript-eslint/eslint-plugin": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
-            "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/scope-manager": "5.43.0",
-                "@typescript-eslint/type-utils": "5.43.0",
-                "@typescript-eslint/utils": "5.43.0",
-                "debug": "^4.3.4",
-                "ignore": "^5.2.0",
-                "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/parser": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
-            "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/scope-manager": "5.43.0",
-                "@typescript-eslint/types": "5.43.0",
-                "@typescript-eslint/typescript-estree": "5.43.0",
-                "debug": "^4.3.4"
-            }
-        },
-        "@typescript-eslint/scope-manager": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
-            "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.43.0",
-                "@typescript-eslint/visitor-keys": "5.43.0"
-            }
-        },
-        "@typescript-eslint/type-utils": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
-            "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/typescript-estree": "5.43.0",
-                "@typescript-eslint/utils": "5.43.0",
-                "debug": "^4.3.4",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/types": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
-            "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
-            "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
-            "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.43.0",
-                "@typescript-eslint/visitor-keys": "5.43.0",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/utils": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
-            "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
-            "dev": true,
-            "requires": {
-                "@types/json-schema": "^7.0.9",
-                "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.43.0",
-                "@typescript-eslint/types": "5.43.0",
-                "@typescript-eslint/typescript-estree": "5.43.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
-                "semver": "^7.3.7"
-            }
-        },
-        "@typescript-eslint/visitor-keys": {
-            "version": "5.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
-            "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.43.0",
-                "eslint-visitor-keys": "^3.3.0"
-            }
-        },
-        "@vscode/test-electron": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.0.tgz",
-            "integrity": "sha512-xk2xrOTMG75/hxO8OVVZ+GErv9gmdZwOD8rEHV3ty3n1Joav2yFcfrmqD6Ukref27U13LEL8gVvSHzauGAK5nQ==",
-            "dev": true,
-            "requires": {
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "rimraf": "^3.0.2",
-                "unzipper": "^0.10.11"
-            },
-            "dependencies": {
-                "agent-base": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-                    "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-                    "dev": true,
-                    "requires": {
-                        "debug": "4"
-                    }
-                },
-                "http-proxy-agent": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-                    "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-                    "dev": true,
-                    "requires": {
-                        "@tootallnate/once": "1",
-                        "agent-base": "6",
-                        "debug": "4"
-                    }
-                },
-                "https-proxy-agent": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-                    "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "6",
-                        "debug": "4"
-                    }
-                },
-                "rimraf": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                }
-            }
-        },
-        "acorn": {
-            "version": "8.8.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-            "dev": true
-        },
-        "acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
-        },
-        "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
-            "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            }
-        },
-        "ansi-colors": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-            "dev": true
-        },
-        "ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true
-        },
-        "ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "requires": {
-                "color-convert": "^2.0.1"
-            }
-        },
-        "anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-            "dev": true,
-            "requires": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-            }
-        },
-        "argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
-        "array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true
-        },
-        "balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
-        },
-        "big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true
-        },
-        "binary": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "dev": true,
-            "requires": {
-                "buffers": "~0.1.1",
-                "chainsaw": "~0.1.0"
-            }
-        },
-        "binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "dev": true
-        },
-        "bluebird": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-            "dev": true
-        },
-        "brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
-            "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
-            "requires": {
-                "fill-range": "^7.0.1"
-            }
-        },
-        "browser-stdout": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-            "dev": true
-        },
-        "buffer-indexof-polyfill": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-            "dev": true
-        },
-        "buffers": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-            "dev": true
-        },
-        "callsites": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true
-        },
-        "camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "dev": true
-        },
-        "chainsaw": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "dev": true,
-            "requires": {
-                "traverse": ">=0.3.0 <0.4"
-            }
-        },
-        "chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            }
-        },
-        "chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "dev": true,
-            "requires": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "fsevents": "~2.3.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.1"
-                    }
-                }
-            }
-        },
-        "cliui": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-            "dev": true,
-            "requires": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^7.0.0"
-            }
-        },
-        "color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "requires": {
-                "color-name": "~1.1.4"
-            }
-        },
-        "color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
-        },
-        "core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
-        },
-        "cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dev": true,
-            "requires": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            }
-        },
-        "debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "requires": {
-                "ms": "2.1.2"
-            }
-        },
-        "decamelize": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-            "dev": true
-        },
-        "deep-is": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true
-        },
-        "diff": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-            "dev": true
-        },
-        "dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "requires": {
-                "path-type": "^4.0.0"
-            }
-        },
-        "doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "requires": {
-                "esutils": "^2.0.2"
-            }
-        },
-        "duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
-            "requires": {
-                "readable-stream": "^2.0.2"
-            }
-        },
-        "emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
-        },
-        "escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true
-        },
-        "escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true
-        },
-        "eslint": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-            "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
-            "dev": true,
-            "requires": {
-                "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.11.6",
-                "@humanwhocodes/module-importer": "^1.0.1",
-                "@nodelib/fs.walk": "^1.2.8",
-                "ajv": "^6.10.0",
-                "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
-                "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.4.0",
-                "esquery": "^1.4.0",
-                "esutils": "^2.0.2",
-                "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
-                "find-up": "^5.0.0",
-                "glob-parent": "^6.0.2",
-                "globals": "^13.15.0",
-                "grapheme-splitter": "^1.0.4",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "is-path-inside": "^3.0.3",
-                "js-sdsl": "^4.1.4",
-                "js-yaml": "^4.1.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.2",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
-                "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0"
-            },
-            "dependencies": {
-                "eslint-scope": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-                    "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.3.0",
-                        "estraverse": "^5.2.0"
-                    }
-                },
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true
-                }
-            }
-        },
-        "eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "requires": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            }
-        },
-        "eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "requires": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-                    "dev": true
-                }
-            }
-        },
-        "eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-            "dev": true
-        },
-        "espree": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
-            "dev": true,
-            "requires": {
-                "acorn": "^8.8.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.3.0"
-            }
-        },
-        "esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^5.1.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true
-                }
-            }
-        },
-        "esrecurse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^5.2.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true
-                }
-            }
-        },
-        "estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true
-        },
-        "esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true
-        },
-        "fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "fast-glob": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.1"
-                    }
-                }
-            }
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
-        },
-        "fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true
-        },
-        "fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-            "dev": true,
-            "requires": {
-                "reusify": "^1.0.4"
-            }
-        },
-        "file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "dev": true,
-            "requires": {
-                "flat-cache": "^3.0.4"
-            }
-        },
-        "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
-            "requires": {
-                "to-regex-range": "^5.0.1"
-            }
-        },
-        "find-up": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
-            "requires": {
-                "locate-path": "^6.0.0",
-                "path-exists": "^4.0.0"
-            }
-        },
-        "flat": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-            "dev": true
-        },
-        "flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-            "dev": true,
-            "requires": {
-                "flatted": "^3.1.0",
-                "rimraf": "^3.0.2"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                }
-            }
-        },
-        "flatted": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-            "dev": true
-        },
-        "fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
-        },
-        "fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "optional": true
-        },
-        "fstream": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-            }
-        },
-        "get-caller-file": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
-        },
-        "glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "dev": true,
-            "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            }
-        },
-        "glob-parent": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
-            "requires": {
-                "is-glob": "^4.0.3"
-            }
-        },
-        "globals": {
-            "version": "13.18.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-            "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^0.20.2"
-            }
-        },
-        "globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "requires": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            }
-        },
-        "graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-            "dev": true
-        },
-        "grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-            "dev": true
-        },
-        "has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true
-        },
-        "he": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-            "dev": true
-        },
-        "ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
-        },
-        "import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-            "dev": true,
-            "requires": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            }
-        },
-        "imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "dev": true
-        },
-        "inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
-            "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
-        },
-        "is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
-            "requires": {
-                "binary-extensions": "^2.0.0"
-            }
-        },
-        "is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
-        },
-        "is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true
-        },
-        "is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "requires": {
-                "is-extglob": "^2.1.1"
-            }
-        },
-        "is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true
-        },
-        "is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true
-        },
-        "is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-            "dev": true
-        },
-        "is-unicode-supported": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-            "dev": true
-        },
-        "isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true
-        },
-        "isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true
-        },
-        "js-sdsl": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-            "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-            "dev": true
-        },
-        "js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "requires": {
-                "argparse": "^2.0.1"
-            }
-        },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
-        },
-        "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true
-        },
-        "jsonc-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-            "dev": true
-        },
-        "levn": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "^1.2.1",
-                "type-check": "~0.4.0"
-            }
-        },
-        "listenercount": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-            "dev": true
-        },
-        "locate-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
-            "requires": {
-                "p-locate": "^5.0.0"
-            }
-        },
-        "lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "log-symbols": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-            "dev": true,
-            "requires": {
-                "chalk": "^4.1.0",
-                "is-unicode-supported": "^0.1.0"
-            }
-        },
-        "lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "requires": {
-                "yallist": "^4.0.0"
-            }
-        },
-        "lunr": {
-            "version": "2.3.9",
-            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-            "dev": true
-        },
-        "marked": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.2.tgz",
-            "integrity": "sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==",
-            "dev": true
-        },
-        "merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true
-        },
-        "micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-            "dev": true,
-            "requires": {
-                "braces": "^3.0.2",
-                "picomatch": "^2.3.1"
-            }
-        },
-        "minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "requires": {
-                "brace-expansion": "^1.1.7"
-            }
-        },
-        "minimist": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-            "dev": true
-        },
-        "mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.6"
-            }
-        },
-        "mocha": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.1.0.tgz",
-            "integrity": "sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==",
-            "dev": true,
-            "requires": {
-                "ansi-colors": "4.1.1",
-                "browser-stdout": "1.3.1",
-                "chokidar": "3.5.3",
-                "debug": "4.3.4",
-                "diff": "5.0.0",
-                "escape-string-regexp": "4.0.0",
-                "find-up": "5.0.0",
-                "glob": "7.2.0",
-                "he": "1.2.0",
-                "js-yaml": "4.1.0",
-                "log-symbols": "4.1.0",
-                "minimatch": "5.0.1",
-                "ms": "2.1.3",
-                "nanoid": "3.3.3",
-                "serialize-javascript": "6.0.0",
-                "strip-json-comments": "3.1.1",
-                "supports-color": "8.1.1",
-                "workerpool": "6.2.1",
-                "yargs": "16.2.0",
-                "yargs-parser": "20.2.4",
-                "yargs-unparser": "2.0.0"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-                    "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "minimatch": {
-                            "version": "3.1.2",
-                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                            "dev": true,
-                            "requires": {
-                                "brace-expansion": "^1.1.7"
-                            }
-                        }
-                    }
-                },
-                "minimatch": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-                    "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    },
-                    "dependencies": {
-                        "brace-expansion": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-                            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-                            "dev": true,
-                            "requires": {
-                                "balanced-match": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
-            }
-        },
-        "ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "nanoid": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-            "dev": true
-        },
-        "natural-compare": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true
-        },
-        "natural-compare-lite": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-            "dev": true
-        },
-        "normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
-        },
-        "once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
-            "requires": {
-                "wrappy": "1"
-            }
-        },
-        "optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-            "dev": true,
-            "requires": {
-                "deep-is": "^0.1.3",
-                "fast-levenshtein": "^2.0.6",
-                "levn": "^0.4.1",
-                "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
-            }
-        },
-        "p-limit": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dev": true,
-            "requires": {
-                "yocto-queue": "^0.1.0"
-            }
-        },
-        "p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
-            "requires": {
-                "p-limit": "^3.0.2"
-            }
-        },
-        "parent-module": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "requires": {
-                "callsites": "^3.0.0"
-            }
-        },
-        "path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true
-        },
-        "path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "path-key": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true
-        },
-        "path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true
-        },
-        "picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true
-        },
-        "prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true
-        },
-        "process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
-        },
-        "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
-        },
-        "queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true
-        },
-        "randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
-        "readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dev": true,
-            "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
-                }
-            }
-        },
-        "readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
-            "requires": {
-                "picomatch": "^2.2.1"
-            }
-        },
-        "regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true
-        },
-        "require-directory": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true
-        },
-        "resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true
-        },
-        "reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true
-        },
-        "rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.3"
-            }
-        },
-        "run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "requires": {
-                "queue-microtask": "^1.2.2"
-            }
-        },
-        "safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true
-        },
-        "semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^6.0.0"
-            }
-        },
-        "serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-            "dev": true,
-            "requires": {
-                "randombytes": "^2.1.0"
-            }
-        },
-        "setimmediate": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "dev": true
-        },
-        "shebang-command": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
-            "requires": {
-                "shebang-regex": "^3.0.0"
-            }
-        },
-        "shebang-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true
-        },
-        "shiki": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-            "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
-            "dev": true,
-            "requires": {
-                "jsonc-parser": "^3.0.0",
-                "vscode-oniguruma": "^1.6.1",
-                "vscode-textmate": "^6.0.0"
-            }
-        },
-        "slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true
-        },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "~5.1.0"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
-                }
-            }
-        },
-        "string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            }
-        },
-        "strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^5.0.1"
-            }
-        },
-        "strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true
-        },
-        "supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "requires": {
-                "has-flag": "^4.0.0"
-            }
-        },
-        "text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
-        },
-        "to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
-            "requires": {
-                "is-number": "^7.0.0"
-            }
-        },
-        "traverse": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-            "dev": true
-        },
-        "tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
-        },
-        "tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
-            }
-        },
-        "type-check": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "^1.2.1"
-            }
-        },
-        "type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true
-        },
-        "typedoc": {
-            "version": "0.23.21",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.21.tgz",
-            "integrity": "sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==",
-            "dev": true,
-            "requires": {
-                "lunr": "^2.3.9",
-                "marked": "^4.0.19",
-                "minimatch": "^5.1.0",
-                "shiki": "^0.11.1"
-            },
-            "dependencies": {
-                "brace-expansion": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-                    "dev": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-                    "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    }
-                }
-            }
-        },
-        "typescript": {
-            "version": "4.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-            "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
-            "dev": true
-        },
-        "unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "dev": true,
-            "requires": {
-                "big-integer": "^1.6.17",
-                "binary": "~0.3.0",
-                "bluebird": "~3.4.1",
-                "buffer-indexof-polyfill": "~1.0.0",
-                "duplexer2": "~0.1.4",
-                "fstream": "^1.0.12",
-                "graceful-fs": "^4.2.2",
-                "listenercount": "~1.0.1",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "~1.0.4"
-            }
-        },
-        "uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "requires": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true
-        },
-        "vscode-oniguruma": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
-            "dev": true
-        },
-        "vscode-textmate": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-            "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
-            "dev": true
-        },
-        "which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
-            "requires": {
-                "isexe": "^2.0.0"
-            }
-        },
-        "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true
-        },
-        "workerpool": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-            "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-            "dev": true
-        },
-        "wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            }
-        },
-        "wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
-        },
-        "y18n": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true
-        },
-        "yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
-        "yargs": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-            "dev": true,
-            "requires": {
-                "cliui": "^7.0.2",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.0",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^20.2.2"
-            }
-        },
-        "yargs-parser": {
-            "version": "20.2.4",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-            "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-            "dev": true
-        },
-        "yargs-unparser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-            "dev": true,
-            "requires": {
-                "camelcase": "^6.0.0",
-                "decamelize": "^4.0.0",
-                "flat": "^5.0.2",
-                "is-plain-obj": "^2.1.0"
-            }
-        },
-        "yocto-queue": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "file-browser",
-    "publisher": "bodil",
+    "name": "vscode-file-browser",
+    "publisher": "alejlatorre",
     "displayName": "File Browser",
     "description": "A nicer alternative to the file open dialog.",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "license": "LGPL-3.0+",
     "author": {
         "name": "Bodil Stokke",
@@ -11,7 +11,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/bodil/vscode-file-browser"
+        "url": "https://github.com/alejlatorre/vscode-file-browser"
     },
     "keywords": [
         "emacs",
@@ -19,7 +19,7 @@
     ],
     "icon": "images/icon.png",
     "engines": {
-        "vscode": "^1.73.1"
+        "vscode": "1.73.1"
     },
     "categories": [
         "Other"

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,19 +1,19 @@
 export enum Action {
-    NewFile,
-    NewFolder,
-    OpenFile,
-    OpenFileBeside,
-    RenameFile,
-    DeleteFile,
-    OpenFolder,
-    OpenFolderInNewWindow,
+  NewFile,
+  NewFolder,
+  OpenFile,
+  OpenFileBeside,
+  RenameFile,
+  DeleteFile,
+  OpenFolder,
+  OpenFolderInNewWindow,
 }
 
 export function action(label: string, action: Action) {
-    return {
-        label,
-        name: "",
-        action,
-        alwaysShow: true,
-    };
+  return {
+    label,
+    name: "",
+    action,
+    alwaysShow: true,
+  };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -320,9 +320,16 @@ class FileBrowser {
 
     openFile(uri: Uri, column: ViewColumn = ViewColumn.Active) {
         this.dispose();
-        vscode.workspace
+        const extension = OSPath.extname(uri.fsPath).slice(1);
+        if (extension === "ipynb") {
+            vscode.workspace
+            .openNotebookDocument(uri)
+            .then((doc) => vscode.window.showNotebookDocument(doc, {viewColumn: column}));
+        } else {
+            vscode.workspace
             .openTextDocument(uri)
             .then((doc) => vscode.window.showTextDocument(doc, column));
+        }
     }
 
     async rename() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,510 +1,550 @@
-import * as vscode from "vscode";
-import { Uri, QuickPickItem, FileType, QuickInputButton, ThemeIcon, ViewColumn } from "vscode";
-import * as OS from "os";
-import * as OSPath from "path";
+import * as vscode from "vscode"
+import {
+  Uri,
+  QuickPickItem,
+  FileType,
+  QuickInputButton,
+  ThemeIcon,
+  ViewColumn,
+} from "vscode"
+import * as OS from "os"
+import * as OSPath from "path"
 
-import { Result, None, Option, Some } from "./rust";
-import { Path, endsWithPathSeparator } from "./path";
-import { Rules } from "./filter";
-import { FileItem, fileRecordCompare } from "./fileitem";
-import { action, Action } from "./action";
+import { Result, None, Option, Some } from "./rust"
+import { Path, endsWithPathSeparator } from "./path"
+import { Rules } from "./filter"
+import { FileItem, fileRecordCompare } from "./fileitem"
+import { action, Action } from "./action"
 
 export enum ConfigItem {
-    RemoveIgnoredFiles = "removeIgnoredFiles",
-    HideDotfiles = "hideDotfiles",
-    HideIgnoreFiles = "hideIgnoredFiles",
-    IgnoreFileTypes = "ignoreFileTypes",
-    LabelIgnoredFiles = "labelIgnoredFiles",
+  RemoveIgnoredFiles = "removeIgnoredFiles",
+  HideDotfiles = "hideDotfiles",
+  HideIgnoreFiles = "hideIgnoredFiles",
+  IgnoreFileTypes = "ignoreFileTypes",
+  LabelIgnoredFiles = "labelIgnoredFiles",
 }
 
 export function config<A>(item: ConfigItem): A | undefined {
-    return vscode.workspace.getConfiguration("file-browser").get(item);
+  return vscode.workspace.getConfiguration("file-browser").get(item)
 }
 
-let active: Option<FileBrowser> = None;
+let active: Option<FileBrowser> = None
 
 function setContext(state: boolean) {
-    vscode.commands.executeCommand("setContext", "inFileBrowser", state);
+  vscode.commands.executeCommand("setContext", "inFileBrowser", state)
 }
 
 interface AutoCompletion {
-    index: number;
-    items: FileItem[];
+  index: number
+  items: FileItem[]
 }
 
 class FileBrowser {
-    current: vscode.QuickPick<FileItem>;
-    path: Path;
-    file: Option<string>;
-    items: FileItem[] = [];
-    pathHistory: { [path: string]: Option<string> };
-    inActions: boolean = false;
-    keepAlive: boolean = false;
-    autoCompletion?: AutoCompletion;
+  current: vscode.QuickPick<FileItem>
+  path: Path
+  file: Option<string>
+  items: FileItem[] = []
+  pathHistory: { [path: string]: Option<string> }
+  inActions: boolean = false
+  keepAlive: boolean = false
+  autoCompletion?: AutoCompletion
 
-    actionsButton: QuickInputButton = {
-        iconPath: new ThemeIcon("ellipsis"),
-        tooltip: "Actions on selected file",
-    };
-    stepOutButton: QuickInputButton = {
-        iconPath: new ThemeIcon("arrow-left"),
-        tooltip: "Step out of folder",
-    };
-    stepInButton: QuickInputButton = {
-        iconPath: new ThemeIcon("arrow-right"),
-        tooltip: "Step into folder",
-    };
+  actionsButton: QuickInputButton = {
+    iconPath: new ThemeIcon("ellipsis"),
+    tooltip: "Actions on selected file",
+  }
+  stepOutButton: QuickInputButton = {
+    iconPath: new ThemeIcon("arrow-left"),
+    tooltip: "Step out of folder",
+  }
+  stepInButton: QuickInputButton = {
+    iconPath: new ThemeIcon("arrow-right"),
+    tooltip: "Step into folder",
+  }
 
-    constructor(path: Path, file: Option<string>) {
-        this.path = path;
-        this.file = file;
-        this.pathHistory = { [this.path.id]: this.file };
-        this.current = vscode.window.createQuickPick();
-        this.current.buttons = [this.actionsButton, this.stepOutButton, this.stepInButton];
-        this.current.placeholder = "Preparing the file list...";
-        this.current.onDidHide(() => {
-            if (!this.keepAlive) {
-                this.dispose();
-            }
-        });
-        this.current.onDidAccept(this.onDidAccept.bind(this));
-        this.current.onDidChangeValue(this.onDidChangeValue.bind(this));
-        this.current.onDidTriggerButton(this.onDidTriggerButton.bind(this));
-        this.update().then(() => {
-            this.current.placeholder = "Type a file name here to search or open a new file";
-            this.current.busy = false;
-        });
+  constructor(path: Path, file: Option<string>) {
+    this.path = path
+    this.file = file
+    this.pathHistory = { [this.path.id]: this.file }
+    this.current = vscode.window.createQuickPick()
+    this.current.buttons = [
+      this.actionsButton,
+      this.stepOutButton,
+      this.stepInButton,
+    ]
+    this.current.placeholder = "Preparing the file list..."
+    this.current.onDidHide(() => {
+      if (!this.keepAlive) {
+        this.dispose()
+      }
+    })
+    this.current.onDidAccept(this.onDidAccept.bind(this))
+    this.current.onDidChangeValue(this.onDidChangeValue.bind(this))
+    this.current.onDidTriggerButton(this.onDidTriggerButton.bind(this))
+    this.update().then(() => {
+      this.current.placeholder =
+        "Type a file name here to search or open a new file"
+      this.current.busy = false
+    })
+  }
+
+  dispose() {
+    setContext(false)
+    this.current.dispose()
+    active = None
+  }
+
+  hide() {
+    this.current.hide()
+    setContext(false)
+  }
+
+  show() {
+    setContext(true)
+    this.current.show()
+  }
+
+  async getStat(uri: Uri): Promise<vscode.FileStat | null> {
+    try {
+      if (uri.scheme === "file") {
+        return await vscode.workspace.fs.stat(uri)
+      } else {
+        const newUri = uri.with({ scheme: "file", fragment: "" })
+        this.path = new Path(newUri)
+        return await vscode.workspace.fs.stat(newUri)
+      }
+    } catch (err) {
+      return null
+    }
+  }
+
+  async update() {
+    // FIXME: temporary and UGLY fix of https://github.com/bodil/vscode-file-browser/issues/35.
+    // Brought in from here https://github.com/atariq11700/vscode-file-browser/commit/a2525d01f262f17dac2c478e56640c9ce1f65713.
+    // this.current.enabled = false;
+    this.current.show()
+    this.current.busy = true
+    this.current.title = this.path.fsPath
+    this.current.value = ""
+
+    const stat = await this.getStat(this.path.uri)
+    if (
+      stat &&
+      this.inActions &&
+      (stat.type & FileType.File) === FileType.File
+    ) {
+      this.items = [
+        action("$(file) Open this file", Action.OpenFile),
+        action(
+          "$(split-horizontal) Open this file to the side",
+          Action.OpenFileBeside,
+        ),
+        action("$(edit) Rename this file", Action.RenameFile),
+        action("$(trash) Delete this file", Action.DeleteFile),
+      ]
+      this.current.items = this.items
+    } else if (
+      stat &&
+      this.inActions &&
+      (stat.type & FileType.Directory) === FileType.Directory
+    ) {
+      this.items = [
+        action("$(folder-opened) Open this folder", Action.OpenFolder),
+        action(
+          "$(folder-opened) Open this folder in a new window",
+          Action.OpenFolderInNewWindow,
+        ),
+        action("$(edit) Rename this folder", Action.RenameFile),
+        action("$(trash) Delete this folder", Action.DeleteFile),
+      ]
+      this.current.items = this.items
+    } else if (
+      stat &&
+      (stat.type & FileType.Directory) === FileType.Directory
+    ) {
+      const records = await vscode.workspace.fs.readDirectory(this.path.uri)
+      records.sort(fileRecordCompare)
+      let items = records.map((entry) => new FileItem(entry))
+      if (config(ConfigItem.HideIgnoreFiles)) {
+        const rules = await Rules.forPath(this.path)
+        items = rules.filter(this.path, items)
+      }
+      if (config(ConfigItem.RemoveIgnoredFiles)) {
+        items = items.filter((item) => item.alwaysShow)
+      }
+      this.items = items
+      this.current.items = items
+      this.current.activeItems = items.filter((item) =>
+        this.file.contains(item.name),
+      )
+    } else {
+      this.items = [
+        action("$(new-folder) Create this folder", Action.NewFolder),
+      ]
+      this.current.items = this.items
+    }
+    this.current.enabled = true
+  }
+
+  onDidChangeValue(value: string, isAutoComplete = false) {
+    if (this.inActions) {
+      return
     }
 
-    dispose() {
-        setContext(false);
-        this.current.dispose();
-        active = None;
+    if (!isAutoComplete) {
+      this.autoCompletion = undefined
     }
 
-    hide() {
-        this.current.hide();
-        setContext(false);
+    const existingItem = this.items.find((item) => item.name === value)
+    if (value === "") {
+      this.current.items = this.items
+      this.current.activeItems = []
+    } else if (existingItem !== undefined) {
+      this.current.items = this.items
+      this.current.activeItems = [existingItem]
+    } else {
+      endsWithPathSeparator(value).match(
+        (path) => {
+          if (path === "~") {
+            this.stepIntoFolder(Path.fromFilePath(OS.homedir()))
+          } else if (path === "..") {
+            this.stepOut()
+          } else {
+            this.stepIntoFolder(this.path.append(path))
+          }
+        },
+        () => {
+          const newItem = {
+            label: `$(new-file) ${value}`,
+            name: value,
+            description: "Open as new file",
+            alwaysShow: true,
+            action: Action.NewFile,
+          }
+          this.current.items = [newItem, ...this.items]
+          this.current.activeItems = [newItem]
+        },
+      )
     }
+  }
 
-    show() {
-        setContext(true);
-        this.current.show();
+  onDidTriggerButton(button: QuickInputButton) {
+    if (button === this.stepInButton) {
+      this.stepIn()
+    } else if (button === this.stepOutButton) {
+      this.stepOut()
+    } else if (button === this.actionsButton) {
+      this.actions()
     }
+  }
 
-    async getStat(uri: Uri): Promise<vscode.FileStat | null> {
-        try {
-            if (uri.scheme === "file") {
-                return await vscode.workspace.fs.stat(uri);
-            } else {
-                const newUri = uri.with({ scheme: "file", fragment: '' });
-                this.path = new Path(newUri);
-                return await vscode.workspace.fs.stat(newUri);
-            }
-        } catch (err) {
-            return null;
+  activeItem(): Option<FileItem> {
+    return new Option(this.current.activeItems[0])
+  }
+
+  async stepIntoFolder(folder: Path) {
+    if (!this.path.equals(folder)) {
+      this.path = folder
+      this.file = this.pathHistory[this.path.id] || None
+      await this.update()
+    }
+  }
+
+  async stepIn() {
+    this.activeItem().ifSome(async (item) => {
+      if (item.action !== undefined) {
+        this.runAction(item)
+      } else if (item.fileType !== undefined) {
+        if ((item.fileType & FileType.Directory) === FileType.Directory) {
+          await this.stepIntoFolder(this.path.append(item.name))
+        } else if ((item.fileType & FileType.File) === FileType.File) {
+          this.path.push(item.name)
+          this.file = None
+          this.inActions = true
+          await this.update()
         }
+      }
+    })
+  }
+
+  async stepOut() {
+    this.inActions = false
+    if (!this.path.atTop()) {
+      this.pathHistory[this.path.id] = this.activeItem().map(
+        (item) => item.name,
+      )
+      this.file = this.path.pop()
+      await this.update()
+    }
+  }
+
+  async actions() {
+    if (this.inActions) {
+      return
+    }
+    await this.activeItem().match(
+      async (item) => {
+        this.inActions = true
+        this.path.push(item.name)
+        this.file = None
+        await this.update()
+      },
+      async () => {
+        this.inActions = true
+        this.file = None
+        await this.update()
+      },
+    )
+  }
+
+  tabCompletion(tabNext: boolean) {
+    if (this.inActions) {
+      return
     }
 
-    async update() {
-        // FIXME: temporary and UGLY fix of https://github.com/bodil/vscode-file-browser/issues/35.
-        // Brought in from here https://github.com/atariq11700/vscode-file-browser/commit/a2525d01f262f17dac2c478e56640c9ce1f65713.
-        // this.current.enabled = false;
-        this.current.show();
-        this.current.busy = true;
-        this.current.title = this.path.fsPath;
-        this.current.value = "";
-
-        const stat = await this.getStat(this.path.uri);
-        if (stat && this.inActions && (stat.type & FileType.File) === FileType.File) {
-            this.items = [
-                action("$(file) Open this file", Action.OpenFile),
-                action("$(split-horizontal) Open this file to the side", Action.OpenFileBeside),
-                action("$(edit) Rename this file", Action.RenameFile),
-                action("$(trash) Delete this file", Action.DeleteFile),
-            ];
-            this.current.items = this.items;
-        } else if (
-            stat &&
-            this.inActions &&
-            (stat.type & FileType.Directory) === FileType.Directory
-        ) {
-            this.items = [
-                action("$(folder-opened) Open this folder", Action.OpenFolder),
-                action(
-                    "$(folder-opened) Open this folder in a new window",
-                    Action.OpenFolderInNewWindow
-                ),
-                action("$(edit) Rename this folder", Action.RenameFile),
-                action("$(trash) Delete this folder", Action.DeleteFile),
-            ];
-            this.current.items = this.items;
-        } else if (stat && (stat.type & FileType.Directory) === FileType.Directory) {
-            const records = await vscode.workspace.fs.readDirectory(this.path.uri);
-            records.sort(fileRecordCompare);
-            let items = records.map((entry) => new FileItem(entry));
-            if (config(ConfigItem.HideIgnoreFiles)) {
-                const rules = await Rules.forPath(this.path);
-                items = rules.filter(this.path, items);
-            }
-            if (config(ConfigItem.RemoveIgnoredFiles)) {
-                items = items.filter((item) => item.alwaysShow);
-            }
-            this.items = items;
-            this.current.items = items;
-            this.current.activeItems = items.filter((item) => this.file.contains(item.name));
-        } else {
-            this.items = [action("$(new-folder) Create this folder", Action.NewFolder)];
-            this.current.items = this.items;
-        }
-        this.current.enabled = true;
+    if (this.autoCompletion) {
+      const length = this.autoCompletion.items.length
+      const step = tabNext ? 1 : -1
+      this.autoCompletion.index =
+        (this.autoCompletion.index + length + step) % length
+    } else {
+      const items = this.items.filter((i) =>
+        i.name.toLowerCase().startsWith(this.current.value.toLowerCase()),
+      )
+      this.autoCompletion = {
+        index: tabNext ? 0 : items.length - 1,
+        items,
+      }
     }
 
-    onDidChangeValue(value: string, isAutoComplete = false) {
-        if (this.inActions) {
-            return;
-        }
+    const newIndex = this.autoCompletion.index
+    const length = this.autoCompletion.items.length
+    if (newIndex < length) {
+      // This also checks out when items is empty
+      const item = this.autoCompletion.items[newIndex]
+      this.current.value = item.name
+      if (length === 1 && item.fileType === FileType.Directory) {
+        this.current.value += "/"
+      }
 
-        if (!isAutoComplete) {
-            this.autoCompletion = undefined;
-        }
-
-        const existingItem = this.items.find((item) => item.name === value);
-        if (value === "") {
-            this.current.items = this.items;
-            this.current.activeItems = [];
-        } else if (existingItem !== undefined) {
-            this.current.items = this.items;
-            this.current.activeItems = [existingItem];
-        } else {
-            endsWithPathSeparator(value).match(
-                (path) => {
-                    if (path === "~") {
-                        this.stepIntoFolder(Path.fromFilePath(OS.homedir()));
-                    } else if (path === "..") {
-                        this.stepOut();
-                    } else {
-                        this.stepIntoFolder(this.path.append(path));
-                    }
-                },
-                () => {
-                    const newItem = {
-                        label: `$(new-file) ${value}`,
-                        name: value,
-                        description: "Open as new file",
-                        alwaysShow: true,
-                        action: Action.NewFile,
-                    };
-                    this.current.items = [newItem, ...this.items];
-                    this.current.activeItems = [newItem];
-                }
-            );
-        }
+      this.onDidChangeValue(this.current.value, true)
     }
+  }
 
-    onDidTriggerButton(button: QuickInputButton) {
-        if (button === this.stepInButton) {
-            this.stepIn();
-        } else if (button === this.stepOutButton) {
-            this.stepOut();
-        } else if (button === this.actionsButton) {
-            this.actions();
+  onDidAccept() {
+    this.autoCompletion = undefined
+    this.activeItem().ifSome((item) => {
+      if (item.action !== undefined) {
+        this.runAction(item)
+      } else if (
+        item.fileType !== undefined &&
+        (item.fileType & FileType.Directory) === FileType.Directory
+      ) {
+        this.stepIn()
+      } else {
+        this.openFile(this.path.append(item.name).uri)
+      }
+    })
+  }
+
+  openFile(uri: Uri, column: ViewColumn = ViewColumn.Active) {
+    this.dispose()
+    const extension = OSPath.extname(uri.fsPath).slice(1)
+    if (extension === "ipynb") {
+      vscode.workspace
+        .openNotebookDocument(uri)
+        .then((doc) =>
+          vscode.window.showNotebookDocument(doc, { viewColumn: column }),
+        )
+    } else {
+      vscode.workspace
+        .openTextDocument(uri)
+        .then((doc) => vscode.window.showTextDocument(doc, column))
+    }
+  }
+
+  async rename() {
+    const uri = this.path.uri
+    const stat = await vscode.workspace.fs.stat(uri)
+    const isDir = (stat.type & FileType.Directory) === FileType.Directory
+    const fileName = this.path.pop().unwrapOrElse(() => {
+      throw new Error("Can't rename an empty file name!")
+    })
+    const fileType = isDir ? "folder" : "file"
+    const workspaceFolder = this.path.getWorkspaceFolder().map((wsf) => wsf.uri)
+    const relPath = workspaceFolder
+      .andThen((workspaceFolder) => new Path(uri).relativeTo(workspaceFolder))
+      .unwrapOr(fileName)
+    const extension = OSPath.extname(relPath)
+    const startSelection = relPath.length - fileName.length
+    const endSelection = startSelection + (fileName.length - extension.length)
+    const result = await vscode.window.showInputBox({
+      prompt: `Enter the new ${fileType} name`,
+      value: relPath,
+      valueSelection: [startSelection, endSelection],
+    })
+    this.file = Some(fileName)
+    if (result !== undefined) {
+      const newUri = workspaceFolder.match(
+        (workspaceFolder) => Uri.joinPath(workspaceFolder, result),
+        () => Uri.joinPath(this.path.uri, result),
+      )
+      if ((await Result.try(vscode.workspace.fs.rename(uri, newUri))).isOk()) {
+        this.file = Some(OSPath.basename(result))
+      } else {
+        vscode.window.showErrorMessage(
+          `Failed to rename ${fileType} "${fileName}"`,
+        )
+      }
+    }
+  }
+
+  async runAction(item: FileItem) {
+    switch (item.action) {
+      case Action.NewFolder: {
+        await vscode.workspace.fs.createDirectory(this.path.uri)
+        await this.update()
+        break
+      }
+      case Action.NewFile: {
+        const uri = this.path.append(item.name).uri
+        this.openFile(uri.with({ scheme: "untitled" }))
+        break
+      }
+      case Action.OpenFile: {
+        const path = this.path.clone()
+        if (item.name && item.name.length > 0) {
+          path.push(item.name)
         }
-    }
-
-    activeItem(): Option<FileItem> {
-        return new Option(this.current.activeItems[0]);
-    }
-
-    async stepIntoFolder(folder: Path) {
-        if (!this.path.equals(folder)) {
-            this.path = folder;
-            this.file = this.pathHistory[this.path.id] || None;
-            await this.update();
+        this.openFile(path.uri)
+        break
+      }
+      case Action.OpenFileBeside: {
+        const path = this.path.clone()
+        if (item.name && item.name.length > 0) {
+          path.push(item.name)
         }
-    }
-
-    async stepIn() {
-        this.activeItem().ifSome(async (item) => {
-            if (item.action !== undefined) {
-                this.runAction(item);
-            } else if (item.fileType !== undefined) {
-                if ((item.fileType & FileType.Directory) === FileType.Directory) {
-                    await this.stepIntoFolder(this.path.append(item.name));
-                } else if ((item.fileType & FileType.File) === FileType.File) {
-                    this.path.push(item.name);
-                    this.file = None;
-                    this.inActions = true;
-                    await this.update();
-                }
-            }
-        });
-    }
-
-    async stepOut() {
-        this.inActions = false;
-        if (!this.path.atTop()) {
-            this.pathHistory[this.path.id] = this.activeItem().map((item) => item.name);
-            this.file = this.path.pop();
-            await this.update();
-        }
-    }
-
-    async actions() {
-        if (this.inActions) {
-            return;
-        }
-        await this.activeItem().match(
-            async (item) => {
-                this.inActions = true;
-                this.path.push(item.name);
-                this.file = None;
-                await this.update();
-            },
-            async () => {
-                this.inActions = true;
-                this.file = None;
-                await this.update();
-            }
-        );
-    }
-
-    tabCompletion(tabNext: boolean) {
-        if (this.inActions) {
-            return;
-        }
-
-        if (this.autoCompletion) {
-            const length = this.autoCompletion.items.length;
-            const step = tabNext ? 1 : -1;
-            this.autoCompletion.index = (this.autoCompletion.index + length + step) % length;
-        } else {
-            const items = this.items.filter((i) =>
-                i.name.toLowerCase().startsWith(this.current.value.toLowerCase())
-            );
-            this.autoCompletion = {
-                index: tabNext ? 0 : items.length - 1,
-                items,
-            };
-        }
-
-        const newIndex = this.autoCompletion.index;
-        const length = this.autoCompletion.items.length;
-        if (newIndex < length) {
-            // This also checks out when items is empty
-            const item = this.autoCompletion.items[newIndex];
-            this.current.value = item.name;
-            if (length === 1 && item.fileType === FileType.Directory) {
-                this.current.value += "/";
-            }
-
-            this.onDidChangeValue(this.current.value, true);
-        }
-    }
-
-    onDidAccept() {
-        this.autoCompletion = undefined;
-        this.activeItem().ifSome((item) => {
-            if (item.action !== undefined) {
-                this.runAction(item);
-            } else if (
-                item.fileType !== undefined &&
-                (item.fileType & FileType.Directory) === FileType.Directory
-            ) {
-                this.stepIn();
-            } else {
-                this.openFile(this.path.append(item.name).uri);
-            }
-        });
-    }
-
-    openFile(uri: Uri, column: ViewColumn = ViewColumn.Active) {
-        this.dispose();
-        const extension = OSPath.extname(uri.fsPath).slice(1);
-        if (extension === "ipynb") {
-            vscode.workspace
-            .openNotebookDocument(uri)
-            .then((doc) => vscode.window.showNotebookDocument(doc, {viewColumn: column}));
-        } else {
-            vscode.workspace
-            .openTextDocument(uri)
-            .then((doc) => vscode.window.showTextDocument(doc, column));
-        }
-    }
-
-    async rename() {
-        const uri = this.path.uri;
-        const stat = await vscode.workspace.fs.stat(uri);
-        const isDir = (stat.type & FileType.Directory) === FileType.Directory;
+        this.openFile(path.uri, ViewColumn.Beside)
+        break
+      }
+      case Action.RenameFile: {
+        this.keepAlive = true
+        this.hide()
+        await this.rename()
+        this.show()
+        this.keepAlive = false
+        this.inActions = false
+        this.update()
+        break
+      }
+      case Action.DeleteFile: {
+        this.keepAlive = true
+        this.hide()
+        const uri = this.path.uri
+        const stat = await vscode.workspace.fs.stat(uri)
+        const isDir = (stat.type & FileType.Directory) === FileType.Directory
         const fileName = this.path.pop().unwrapOrElse(() => {
-            throw new Error("Can't rename an empty file name!");
-        });
-        const fileType = isDir ? "folder" : "file";
-        const workspaceFolder = this.path.getWorkspaceFolder().map((wsf) => wsf.uri);
-        const relPath = workspaceFolder
-            .andThen((workspaceFolder) => new Path(uri).relativeTo(workspaceFolder))
-            .unwrapOr(fileName);
-        const extension = OSPath.extname(relPath);
-        const startSelection = relPath.length - fileName.length;
-        const endSelection = startSelection + (fileName.length - extension.length);
-        const result = await vscode.window.showInputBox({
-            prompt: `Enter the new ${fileType} name`,
-            value: relPath,
-            valueSelection: [startSelection, endSelection],
-        });
-        this.file = Some(fileName);
-        if (result !== undefined) {
-            const newUri = workspaceFolder.match(
-                (workspaceFolder) => Uri.joinPath(workspaceFolder, result),
-                () => Uri.joinPath(this.path.uri, result)
-            );
-            if ((await Result.try(vscode.workspace.fs.rename(uri, newUri))).isOk()) {
-                this.file = Some(OSPath.basename(result));
-            } else {
-                vscode.window.showErrorMessage(
-                    `Failed to rename ${fileType} "${fileName}"`
-                );
-            }
+          throw new Error("Can't delete an empty file name!")
+        })
+        const fileType = isDir ? "folder" : "file"
+        const goAhead = `$(trash) Delete the ${fileType} "${fileName}"`
+        const result = await vscode.window.showQuickPick(
+          ["$(close) Cancel", goAhead],
+          {},
+        )
+        if (result === goAhead) {
+          const delOp = await Result.try(
+            vscode.workspace.fs.delete(uri, { recursive: isDir }),
+          )
+          if (delOp.isErr()) {
+            vscode.window.showErrorMessage(
+              `Failed to delete ${fileType} "${fileName}"`,
+            )
+          }
         }
+        this.show()
+        this.keepAlive = false
+        this.inActions = false
+        this.update()
+        break
+      }
+      case Action.OpenFolder: {
+        vscode.commands.executeCommand("vscode.openFolder", this.path.uri)
+        break
+      }
+      case Action.OpenFolderInNewWindow: {
+        vscode.commands.executeCommand("vscode.openFolder", this.path.uri, true)
+        break
+      }
+      default:
+        throw new Error(`Unhandled action ${item.action}`)
     }
-
-    async runAction(item: FileItem) {
-        switch (item.action) {
-            case Action.NewFolder: {
-                await vscode.workspace.fs.createDirectory(this.path.uri);
-                await this.update();
-                break;
-            }
-            case Action.NewFile: {
-                const uri = this.path.append(item.name).uri;
-                this.openFile(uri.with({ scheme: "untitled" }));
-                break;
-            }
-            case Action.OpenFile: {
-                const path = this.path.clone();
-                if (item.name && item.name.length > 0) {
-                    path.push(item.name);
-                }
-                this.openFile(path.uri);
-                break;
-            }
-            case Action.OpenFileBeside: {
-                const path = this.path.clone();
-                if (item.name && item.name.length > 0) {
-                    path.push(item.name);
-                }
-                this.openFile(path.uri, ViewColumn.Beside);
-                break;
-            }
-            case Action.RenameFile: {
-                this.keepAlive = true;
-                this.hide();
-                await this.rename();
-                this.show();
-                this.keepAlive = false;
-                this.inActions = false;
-                this.update();
-                break;
-            }
-            case Action.DeleteFile: {
-                this.keepAlive = true;
-                this.hide();
-                const uri = this.path.uri;
-                const stat = await vscode.workspace.fs.stat(uri);
-                const isDir = (stat.type & FileType.Directory) === FileType.Directory;
-                const fileName = this.path.pop().unwrapOrElse(() => {
-                    throw new Error("Can't delete an empty file name!");
-                });
-                const fileType = isDir ? "folder" : "file";
-                const goAhead = `$(trash) Delete the ${fileType} "${fileName}"`;
-                const result = await vscode.window.showQuickPick(["$(close) Cancel", goAhead], {});
-                if (result === goAhead) {
-                    const delOp = await Result.try(
-                        vscode.workspace.fs.delete(uri, { recursive: isDir })
-                    );
-                    if (delOp.isErr()) {
-                        vscode.window.showErrorMessage(
-                            `Failed to delete ${fileType} "${fileName}"`
-                        );
-                    }
-                }
-                this.show();
-                this.keepAlive = false;
-                this.inActions = false;
-                this.update();
-                break;
-            }
-            case Action.OpenFolder: {
-                vscode.commands.executeCommand("vscode.openFolder", this.path.uri);
-                break;
-            }
-            case Action.OpenFolderInNewWindow: {
-                vscode.commands.executeCommand("vscode.openFolder", this.path.uri, true);
-                break;
-            }
-            default:
-                throw new Error(`Unhandled action ${item.action}`);
-        }
-    }
+  }
 }
 
 export function activate(context: vscode.ExtensionContext) {
-    setContext(false);
+  setContext(false)
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("file-browser.open", () => {
-            const document = vscode.window.activeTextEditor?.document;
-            let workspaceFolder =
-                vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0];
-            let path = new Path(workspaceFolder?.uri || Uri.file(OS.homedir()));
-            let file: Option<string> = None;
-            if (document && !document.isUntitled) {
-                path = new Path(document.uri);
-                file = path.pop();
-            }
-            active = Some(new FileBrowser(path, file));
-            setContext(true);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("file-browser.open", () => {
+      const document = vscode.window.activeTextEditor?.document
+      let workspaceFolder =
+        vscode.workspace.workspaceFolders &&
+        vscode.workspace.workspaceFolders[0]
+      let path = new Path(workspaceFolder?.uri || Uri.file(OS.homedir()))
+      let file: Option<string> = None
+      if (document && !document.isUntitled) {
+        path = new Path(document.uri)
+        file = path.pop()
+      }
+      active = Some(new FileBrowser(path, file))
+      setContext(true)
+    }),
+  )
+  context.subscriptions.push(
+    vscode.commands.registerCommand("file-browser.rename", () =>
+      active
+        .orElse(() => {
+          const document = vscode.window.activeTextEditor?.document
+          let workspaceFolder =
+            vscode.workspace.workspaceFolders &&
+            vscode.workspace.workspaceFolders[0]
+          let path = new Path(
+            document?.uri || workspaceFolder?.uri || Uri.file(OS.homedir()),
+          )
+          active = Some(new FileBrowser(path, None))
+          setContext(true)
+          return active
         })
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand("file-browser.rename", () =>
-            active.orElse(() => {
-                const document = vscode.window.activeTextEditor?.document;
-                let workspaceFolder =
-                    vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0];
-                let path = new Path(document?.uri || workspaceFolder?.uri || Uri.file(OS.homedir()));
-                active = Some(new FileBrowser(path, None));
-                setContext(true);
-                return active;
-            }).ifSome((active) => active.rename())
-        )
-    );
+        .ifSome((active) => active.rename()),
+    ),
+  )
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("file-browser.stepIn", () =>
-            active.ifSome((active) => active.stepIn())
-        )
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand("file-browser.stepOut", () =>
-            active.ifSome((active) => active.stepOut())
-        )
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand("file-browser.actions", () =>
-            active.ifSome((active) => active.actions())
-        )
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand("file-browser.tabNext", () =>
-            active.ifSome((active) => active.tabCompletion(true))
-        )
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand("file-browser.tabPrev", () =>
-            active.ifSome((active) => active.tabCompletion(false))
-        )
-    );
+  context.subscriptions.push(
+    vscode.commands.registerCommand("file-browser.stepIn", () =>
+      active.ifSome((active) => active.stepIn()),
+    ),
+  )
+  context.subscriptions.push(
+    vscode.commands.registerCommand("file-browser.stepOut", () =>
+      active.ifSome((active) => active.stepOut()),
+    ),
+  )
+  context.subscriptions.push(
+    vscode.commands.registerCommand("file-browser.actions", () =>
+      active.ifSome((active) => active.actions()),
+    ),
+  )
+  context.subscriptions.push(
+    vscode.commands.registerCommand("file-browser.tabNext", () =>
+      active.ifSome((active) => active.tabCompletion(true)),
+    ),
+  )
+  context.subscriptions.push(
+    vscode.commands.registerCommand("file-browser.tabPrev", () =>
+      active.ifSome((active) => active.tabCompletion(false)),
+    ),
+  )
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,6 +92,20 @@ class FileBrowser {
         this.current.show();
     }
 
+    async getStat(uri: Uri): Promise<vscode.FileStat | null> {
+        try {
+            if (uri.scheme === "file") {
+                return await vscode.workspace.fs.stat(uri);
+            } else {
+                const newUri = uri.with({ scheme: "file", fragment: '' });
+                this.path = new Path(newUri);
+                return await vscode.workspace.fs.stat(newUri);
+            }
+        } catch (err) {
+            return null;
+        }
+    }
+
     async update() {
         // FIXME: temporary and UGLY fix of https://github.com/bodil/vscode-file-browser/issues/35.
         // Brought in from here https://github.com/atariq11700/vscode-file-browser/commit/a2525d01f262f17dac2c478e56640c9ce1f65713.
@@ -101,7 +115,7 @@ class FileBrowser {
         this.current.title = this.path.fsPath;
         this.current.value = "";
 
-        const stat = (await Result.try(vscode.workspace.fs.stat(this.path.uri))).unwrap();
+        const stat = await this.getStat(this.path.uri);
         if (stat && this.inActions && (stat.type & FileType.File) === FileType.File) {
             this.items = [
                 action("$(file) Open this file", Action.OpenFile),

--- a/src/fileitem.ts
+++ b/src/fileitem.ts
@@ -4,56 +4,61 @@ import { Action } from "./action";
 import { config, ConfigItem } from "./extension";
 
 export class FileItem implements QuickPickItem {
-    name: string;
-    label: string;
-    alwaysShow: boolean;
-    detail?: string;
-    description?: string;
-    fileType?: FileType;
-    action?: Action;
+  name: string;
+  label: string;
+  alwaysShow: boolean;
+  detail?: string;
+  description?: string;
+  fileType?: FileType;
+  action?: Action;
 
-    constructor(record: [string, FileType]) {
-        const [name, fileType] = record;
-        this.name = name;
-        this.fileType = fileType;
-        this.alwaysShow = config(ConfigItem.HideDotfiles) ? !name.startsWith(".") : true;
-        switch (this.fileType) {
-            case FileType.Directory:
-                this.label = `$(folder) ${name}`;
-                break;
-            case FileType.Directory | FileType.SymbolicLink:
-                this.label = `$(file-symlink-directory) ${name}`;
-                break;
-            case FileType.File | FileType.SymbolicLink:
-                this.label = `$(file-symlink-file) ${name}`;
-            default:
-                this.label = `$(file) ${name}`;
-                break;
-        }
+  constructor(record: [string, FileType]) {
+    const [name, fileType] = record;
+    this.name = name;
+    this.fileType = fileType;
+    this.alwaysShow = config(ConfigItem.HideDotfiles)
+      ? !name.startsWith(".")
+      : true;
+    switch (this.fileType) {
+      case FileType.Directory:
+        this.label = `$(folder) ${name}`;
+        break;
+      case FileType.Directory | FileType.SymbolicLink:
+        this.label = `$(file-symlink-directory) ${name}`;
+        break;
+      case FileType.File | FileType.SymbolicLink:
+        this.label = `$(file-symlink-file) ${name}`;
+      default:
+        this.label = `$(file) ${name}`;
+        break;
     }
+  }
 }
 
 export function itemIsDir(item: FileItem): boolean {
-    if (item.fileType === undefined) {
-        return false;
-    }
-    return !!(item.fileType | FileType.Directory);
+  if (item.fileType === undefined) {
+    return false;
+  }
+  return !!(item.fileType | FileType.Directory);
 }
 
-export function fileRecordCompare(left: [string, FileType], right: [string, FileType]): -1 | 0 | 1 {
-    const [leftName, leftDir] = [
-        left[0].toLowerCase(),
-        (left[1] & FileType.Directory) === FileType.Directory,
-    ];
-    const [rightName, rightDir] = [
-        right[0].toLowerCase(),
-        (right[1] & FileType.Directory) === FileType.Directory,
-    ];
-    if (leftDir && !rightDir) {
-        return -1;
-    }
-    if (rightDir && !leftDir) {
-        return 1;
-    }
-    return leftName > rightName ? 1 : leftName === rightName ? 0 : -1;
+export function fileRecordCompare(
+  left: [string, FileType],
+  right: [string, FileType]
+): -1 | 0 | 1 {
+  const [leftName, leftDir] = [
+    left[0].toLowerCase(),
+    (left[1] & FileType.Directory) === FileType.Directory,
+  ];
+  const [rightName, rightDir] = [
+    right[0].toLowerCase(),
+    (right[1] & FileType.Directory) === FileType.Directory,
+  ];
+  if (leftDir && !rightDir) {
+    return -1;
+  }
+  if (rightDir && !leftDir) {
+    return 1;
+  }
+  return leftName > rightName ? 1 : leftName === rightName ? 0 : -1;
 }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -9,62 +9,66 @@ import * as OSPath from "path";
 import { config, ConfigItem } from "./extension";
 
 export class Rules {
-    private path: Path;
-    private name: string;
-    private rules: Ignore;
+  private path: Path;
+  private name: string;
+  private rules: Ignore;
 
-    private constructor(path: Path) {
-        this.path = path;
-        this.rules = ignore();
-        this.name = "empty";
+  private constructor(path: Path) {
+    this.path = path;
+    this.rules = ignore();
+    this.name = "empty";
+  }
+
+  static async forPath(path: Path): Promise<Rules> {
+    const ruleFileNames: string[] | undefined = config(
+      ConfigItem.IgnoreFileTypes
+    );
+    if (ruleFileNames === undefined) {
+      return new Rules(path);
     }
+    const ruleFilePath = await lookUpwards(path.uri, ruleFileNames);
+    return ruleFilePath.match(
+      async (ruleFilePath) => await Rules.read(ruleFilePath),
+      async () => new Rules(path)
+    );
+  }
 
-    static async forPath(path: Path): Promise<Rules> {
-        const ruleFileNames: string[] | undefined = config(ConfigItem.IgnoreFileTypes);
-        if (ruleFileNames === undefined) {
-            return new Rules(path);
-        }
-        const ruleFilePath = await lookUpwards(path.uri, ruleFileNames);
-        return ruleFilePath.match(
-            async (ruleFilePath) => await Rules.read(ruleFilePath),
-            async () => new Rules(path)
-        );
-    }
+  static async read(ruleFilePath: Uri): Promise<Rules> {
+    const ruleString = (
+      await vscode.workspace.fs.readFile(ruleFilePath)
+    ).toString();
+    const ruleList = ruleString.trim().split(/\r?\n/);
+    const rules = new Rules(new Path(ruleFilePath).parent());
+    rules.name = OSPath.basename(ruleFilePath.path);
+    rules.add(ruleList);
+    return rules;
+  }
 
-    static async read(ruleFilePath: Uri): Promise<Rules> {
-        const ruleString = (await vscode.workspace.fs.readFile(ruleFilePath)).toString();
-        const ruleList = ruleString.trim().split(/\r?\n/);
-        const rules = new Rules(new Path(ruleFilePath).parent());
-        rules.name = OSPath.basename(ruleFilePath.path);
-        rules.add(ruleList);
-        return rules;
-    }
+  private add(rules: string[]) {
+    this.rules.add(rules);
+  }
 
-    private add(rules: string[]) {
-        this.rules.add(rules);
-    }
-
-    filter(base: Path, items: FileItem[]): FileItem[] {
-        return items.map((item) => {
-            let path = base
-                .append(item.name)
-                .relativeTo(this.path.uri)
-                .unwrapOrElse(() => {
-                    throw new Error(
-                        "Tried to apply ignore rules to a path that wasn't relative to the rule path!"
-                    );
-                });
-            if (itemIsDir(item)) {
-                path += "/";
-            }
-            const ignored = this.rules.test(path).ignored;
-            if (ignored) {
-                item.alwaysShow = false;
-                if (config(ConfigItem.LabelIgnoredFiles)) {
-                    item.description = `(in ${this.name})`;
-                }
-            }
-            return item;
+  filter(base: Path, items: FileItem[]): FileItem[] {
+    return items.map((item) => {
+      let path = base
+        .append(item.name)
+        .relativeTo(this.path.uri)
+        .unwrapOrElse(() => {
+          throw new Error(
+            "Tried to apply ignore rules to a path that wasn't relative to the rule path!"
+          );
         });
-    }
+      if (itemIsDir(item)) {
+        path += "/";
+      }
+      const ignored = this.rules.test(path).ignored;
+      if (ignored) {
+        item.alwaysShow = false;
+        if (config(ConfigItem.LabelIgnoredFiles)) {
+          item.description = `(in ${this.name})`;
+        }
+      }
+      return item;
+    });
+  }
 }

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,135 +1,144 @@
 import * as vscode from "vscode";
-import { Uri, WorkspaceFolder, FileStat, FileType, FileSystemError } from "vscode";
+import {
+  Uri,
+  WorkspaceFolder,
+  FileStat,
+  FileType,
+  FileSystemError,
+} from "vscode";
 import * as OSPath from "path";
 import { Option, None, Some, Result, Err, Ok } from "./rust";
 
 export class Path {
-    private pathUri: Uri;
+  private pathUri: Uri;
 
-    constructor(uri: Uri) {
-        this.pathUri = uri;
+  constructor(uri: Uri) {
+    this.pathUri = uri;
+  }
+
+  static fromFilePath(filePath: string): Path {
+    return new Path(Uri.file(filePath));
+  }
+
+  get uri(): Uri {
+    return this.pathUri;
+  }
+
+  /**
+   * Get a unique identifier string for the [[Path]]. Do not display this to the user.
+   */
+  get id(): string {
+    return this.pathUri.toString(false);
+  }
+
+  get fsPath(): string {
+    return this.pathUri.fsPath;
+  }
+
+  /**
+   * Get the path component of the [[Path]] as a string.
+   */
+  // get pathString(): string {
+  //     return this.pathUri.path;
+  // }
+
+  /**
+   * Make a copy of this path.
+   */
+  clone(): Path {
+    return new Path(this.pathUri);
+  }
+
+  equals(other: Path) {
+    return this.id === other.id;
+  }
+
+  /**
+   * Test if the path is at its root.
+   */
+  atTop(): boolean {
+    return this.pathUri === Uri.joinPath(this.pathUri, "..");
+  }
+
+  /**
+   * Get the root of the file system the [[Path]] resides in.
+   */
+  root(): Uri {
+    return this.pathUri.with({ path: "/" });
+  }
+
+  /**
+   * Return a new path with the provided segments appended.
+   */
+  append(...pathSegments: string[]): Path {
+    return new Path(Uri.joinPath(this.pathUri, ...pathSegments));
+  }
+
+  /**
+   * Return the parent of a path.
+   *
+   * This always succeeds; if the path has no parent, it returns itself.
+   * Use [[`Path.atTop`]] to check whether a path has a parent.
+   */
+  parent(): Path {
+    return this.append("..");
+  }
+
+  /**
+   * Push `pathSegments` onto the end of the path.
+   */
+  push(...pathSegments: string[]) {
+    this.pathUri = Uri.joinPath(this.pathUri, ...pathSegments);
+  }
+
+  /**
+   * Pop the last path segment off the path.
+   *
+   * @returns [[None]] if the path has no more segments to pop.
+   */
+  pop(): Option<string> {
+    if (this.atTop()) {
+      return None;
     }
+    const current = new Path(this.pathUri);
+    this.pathUri = Uri.joinPath(this.pathUri, "..");
+    return current.relativeTo(this.pathUri);
+  }
 
-    static fromFilePath(filePath: string): Path {
-        return new Path(Uri.file(filePath));
+  getWorkspaceFolder(): Option<WorkspaceFolder> {
+    return new Option(vscode.workspace.getWorkspaceFolder(this.pathUri));
+  }
+
+  relativeTo(other: Uri): Option<string> {
+    if (
+      this.pathUri.authority !== other.authority ||
+      this.pathUri.scheme !== other.scheme
+    ) {
+      return None;
     }
+    const relPath = OSPath.relative(other.fsPath, this.pathUri.fsPath);
+    return Some(relPath);
+  }
 
-    get uri(): Uri {
-        return this.pathUri;
-    }
+  async stat(): Promise<Result<FileStat, Error>> {
+    return Result.try(vscode.workspace.fs.stat(this.pathUri));
+  }
 
-    /**
-     * Get a unique identifier string for the [[Path]]. Do not display this to the user.
-     */
-    get id(): string {
-        return this.pathUri.toString(false);
-    }
+  async isDir(): Promise<boolean> {
+    const stat = await this.stat();
+    return stat.match(
+      (stat) => !!(stat.type | FileType.Directory),
+      () => false
+    );
+  }
 
-    get fsPath(): string {
-        return this.pathUri.fsPath;
-    }
-
-    /**
-     * Get the path component of the [[Path]] as a string.
-     */
-    // get pathString(): string {
-    //     return this.pathUri.path;
-    // }
-
-    /**
-     * Make a copy of this path.
-     */
-    clone(): Path {
-        return new Path(this.pathUri);
-    }
-
-    equals(other: Path) {
-        return this.id === other.id;
-    }
-
-    /**
-     * Test if the path is at its root.
-     */
-    atTop(): boolean {
-        return this.pathUri === Uri.joinPath(this.pathUri, "..");
-    }
-
-    /**
-     * Get the root of the file system the [[Path]] resides in.
-     */
-    root(): Uri {
-        return this.pathUri.with({ path: "/" });
-    }
-
-    /**
-     * Return a new path with the provided segments appended.
-     */
-    append(...pathSegments: string[]): Path {
-        return new Path(Uri.joinPath(this.pathUri, ...pathSegments));
-    }
-
-    /**
-     * Return the parent of a path.
-     *
-     * This always succeeds; if the path has no parent, it returns itself.
-     * Use [[`Path.atTop`]] to check whether a path has a parent.
-     */
-    parent(): Path {
-        return this.append("..");
-    }
-
-    /**
-     * Push `pathSegments` onto the end of the path.
-     */
-    push(...pathSegments: string[]) {
-        this.pathUri = Uri.joinPath(this.pathUri, ...pathSegments);
-    }
-
-    /**
-     * Pop the last path segment off the path.
-     *
-     * @returns [[None]] if the path has no more segments to pop.
-     */
-    pop(): Option<string> {
-        if (this.atTop()) {
-            return None;
-        }
-        const current = new Path(this.pathUri);
-        this.pathUri = Uri.joinPath(this.pathUri, "..");
-        return current.relativeTo(this.pathUri);
-    }
-
-    getWorkspaceFolder(): Option<WorkspaceFolder> {
-        return new Option(vscode.workspace.getWorkspaceFolder(this.pathUri));
-    }
-
-    relativeTo(other: Uri): Option<string> {
-        if (this.pathUri.authority !== other.authority || this.pathUri.scheme !== other.scheme) {
-            return None;
-        }
-        const relPath = OSPath.relative(other.fsPath, this.pathUri.fsPath);
-        return Some(relPath);
-    }
-
-    async stat(): Promise<Result<FileStat, Error>> {
-        return Result.try(vscode.workspace.fs.stat(this.pathUri));
-    }
-
-    async isDir(): Promise<boolean> {
-        const stat = await this.stat();
-        return stat.match(
-            (stat) => !!(stat.type | FileType.Directory),
-            () => false
-        );
-    }
-
-    async isFile(): Promise<boolean> {
-        const stat = await this.stat();
-        return stat.match(
-            (stat) => !!(stat.type | FileType.File),
-            () => false
-        );
-    }
+  async isFile(): Promise<boolean> {
+    const stat = await this.stat();
+    return stat.match(
+      (stat) => !!(stat.type | FileType.File),
+      () => false
+    );
+  }
 }
 
 /**
@@ -137,13 +146,13 @@ export class Path {
  * Otherwise, return [[None]].
  */
 export function endsWithPathSeparator(value: string): Option<string> {
-    if (value.endsWith("/")) {
-        return Some(value.slice(0, value.length - 1));
-    }
-    if (value.endsWith(OSPath.sep)) {
-        return Some(value.slice(0, value.length - OSPath.sep.length));
-    }
-    return None;
+  if (value.endsWith("/")) {
+    return Some(value.slice(0, value.length - 1));
+  }
+  if (value.endsWith(OSPath.sep)) {
+    return Some(value.slice(0, value.length - OSPath.sep.length));
+  }
+  return None;
 }
 
 /**
@@ -158,22 +167,22 @@ export function endsWithPathSeparator(value: string): Option<string> {
  * Returns either the [[Uri]] of the first file found, or [[None]].
  */
 export async function lookUpwards(
-    uri: Uri,
-    files: string[]
+  uri: Uri,
+  files: string[]
 ): Promise<Result<Uri, FileSystemError>> {
-    const path = new Path(uri);
-    if (!(await path.isDir())) {
-        return Err(FileSystemError.FileNotADirectory(uri));
+  const path = new Path(uri);
+  if (!(await path.isDir())) {
+    return Err(FileSystemError.FileNotADirectory(uri));
+  }
+  while (true) {
+    for (const file of files) {
+      let filePath = path.append(file);
+      if (await filePath.isFile()) {
+        return Ok(filePath.uri);
+      }
     }
-    while (true) {
-        for (const file of files) {
-            let filePath = path.append(file);
-            if (await filePath.isFile()) {
-                return Ok(filePath.uri);
-            }
-        }
-        if (path.pop().isNone()) {
-            return Err(FileSystemError.FileNotFound());
-        }
+    if (path.pop().isNone()) {
+      return Err(FileSystemError.FileNotFound());
     }
+  }
 }

--- a/src/rust.ts
+++ b/src/rust.ts
@@ -4,168 +4,168 @@
  * The identity function. Returns its input unmodified.
  */
 export function id<A>(value: A): A {
-    return value;
+  return value;
 }
 
 /**
  * Construct a function which always returns the provided value.
  */
 export function constant<A>(value: A): () => A {
-    return () => value;
+  return () => value;
 }
 
 /**
  * A nullable value of type `A`.
  */
 export class Option<A> {
-    private option: A | undefined;
+  private option: A | undefined;
 
-    /**
-     * Construct an [[Option]] from a nullable value of `A`.
-     */
-    constructor(value: A | undefined) {
-        this.option = value;
-    }
+  /**
+   * Construct an [[Option]] from a nullable value of `A`.
+   */
+  constructor(value: A | undefined) {
+    this.option = value;
+  }
 
-    /**
-     * Convert a [[Thenable]] returning `A` into a [[Thenable]] returning an [[Option]] of `A`, or `None` if the [[Thenable]] fails.
-     * The new [[Thenable]] always succeeds, reflecting an error condition in the `Option` instead of the failure callback.
-     */
-    static try<A>(m: Thenable<A>): Thenable<Option<A>> {
-        return m.then(Some, constant(None));
-    }
+  /**
+   * Convert a [[Thenable]] returning `A` into a [[Thenable]] returning an [[Option]] of `A`, or `None` if the [[Thenable]] fails.
+   * The new [[Thenable]] always succeeds, reflecting an error condition in the `Option` instead of the failure callback.
+   */
+  static try<A>(m: Thenable<A>): Thenable<Option<A>> {
+    return m.then(Some, constant(None));
+  }
 
-    /**
-     * In the absence of pattern matching in the language, the `match` function takes two callbacks, one for each possible
-     * state of the [[Option]], and calls the one that matches the actual state.
-     */
-    match<B>(onSome: (value: A) => B, onNone: () => B): B {
-        if (this.option === undefined) {
-            return onNone();
-        } else {
-            return onSome(this.option);
-        }
+  /**
+   * In the absence of pattern matching in the language, the `match` function takes two callbacks, one for each possible
+   * state of the [[Option]], and calls the one that matches the actual state.
+   */
+  match<B>(onSome: (value: A) => B, onNone: () => B): B {
+    if (this.option === undefined) {
+      return onNone();
+    } else {
+      return onSome(this.option);
     }
+  }
 
-    /**
-     * Test if the [[Option]] contains a value.
-     */
-    isSome(): boolean {
-        return this.option !== undefined;
-    }
+  /**
+   * Test if the [[Option]] contains a value.
+   */
+  isSome(): boolean {
+    return this.option !== undefined;
+  }
 
-    /**
-     * Test if the [[Option]] is null.
-     */
-    isNone(): boolean {
-        return this.option === undefined;
-    }
+  /**
+   * Test if the [[Option]] is null.
+   */
+  isNone(): boolean {
+    return this.option === undefined;
+  }
 
-    /**
-     * Test if the [[Option]] contains a value that's equal to `value`.
-     */
-    contains(value: A): boolean {
-        return this.option === value;
-    }
+  /**
+   * Test if the [[Option]] contains a value that's equal to `value`.
+   */
+  contains(value: A): boolean {
+    return this.option === value;
+  }
 
-    /**
-     * Call the provided function with the contained value if the [[Option]] is non-null.
-     */
-    ifSome(onSome: (value: A) => void) {
-        this.match(onSome, constant({}));
-    }
+  /**
+   * Call the provided function with the contained value if the [[Option]] is non-null.
+   */
+  ifSome(onSome: (value: A) => void) {
+    this.match(onSome, constant({}));
+  }
 
-    /**
-     * Call the provided function if the [[Option]] is null.
-     */
-    ifNone(onNone: () => void) {
-        this.match(constant({}), onNone);
-    }
+  /**
+   * Call the provided function if the [[Option]] is null.
+   */
+  ifNone(onNone: () => void) {
+    this.match(constant({}), onNone);
+  }
 
-    /**
-     * If the [[Option]] is non-null, call the provided function with the contained value and
-     * return a new [[Option]] containing the result of the function, which must be another [[Option]].
-     */
-    andThen<B>(f: (value: A) => Option<B>): Option<B> {
-        return this.match(f, constant(None));
-    }
+  /**
+   * If the [[Option]] is non-null, call the provided function with the contained value and
+   * return a new [[Option]] containing the result of the function, which must be another [[Option]].
+   */
+  andThen<B>(f: (value: A) => Option<B>): Option<B> {
+    return this.match(f, constant(None));
+  }
 
-    /**
-     * If the [[Option]] is null, call the provided function and return its result, which must be another [[Option]] of `A`.
-     */
-    orElse(f: () => Option<A>): Option<A> {
-        return this.match(Some, f);
-    }
+  /**
+   * If the [[Option]] is null, call the provided function and return its result, which must be another [[Option]] of `A`.
+   */
+  orElse(f: () => Option<A>): Option<A> {
+    return this.match(Some, f);
+  }
 
-    /**
-     * If the [[Option]] is non-null, transform its contained value using the provided function.
-     */
-    map<B>(f: (value: A) => B): Option<B> {
-        return this.andThen((v) => Some(f(v)));
-    }
+  /**
+   * If the [[Option]] is non-null, transform its contained value using the provided function.
+   */
+  map<B>(f: (value: A) => B): Option<B> {
+    return this.andThen((v) => Some(f(v)));
+  }
 
-    /**
-     * If the [[Option]] is non-null, return the provided [[Option]] of `B`, otherwise return [[None]].
-     */
-    and<B>(option: Option<B>): Option<B> {
-        return this.andThen(constant(option));
-    }
+  /**
+   * If the [[Option]] is non-null, return the provided [[Option]] of `B`, otherwise return [[None]].
+   */
+  and<B>(option: Option<B>): Option<B> {
+    return this.andThen(constant(option));
+  }
 
-    /**
-     * If the [[Option]] is null, return the provided [[Option]], otherwise return the original [[Option]].
-     */
-    or(option: Option<A>): Option<A> {
-        return this.orElse(constant(option));
-    }
+  /**
+   * If the [[Option]] is null, return the provided [[Option]], otherwise return the original [[Option]].
+   */
+  or(option: Option<A>): Option<A> {
+    return this.orElse(constant(option));
+  }
 
-    /**
-     * Return the value contained in the [[Option]] if it's non-null, or return `defaultValue` otherwise.
-     */
-    getOr(defaultValue: A): A {
-        return this.match(id, constant(defaultValue));
-    }
+  /**
+   * Return the value contained in the [[Option]] if it's non-null, or return `defaultValue` otherwise.
+   */
+  getOr(defaultValue: A): A {
+    return this.match(id, constant(defaultValue));
+  }
 
-    /**
-     * Return the value contained in the [[Option]] if it's non-null, or call the provided function and return its result otherwise.
-     */
-    getOrElse(f: () => A): A {
-        return this.match(id, f);
-    }
+  /**
+   * Return the value contained in the [[Option]] if it's non-null, or call the provided function and return its result otherwise.
+   */
+  getOrElse(f: () => A): A {
+    return this.match(id, f);
+  }
 
-    /**
-     * Convert the [[Option]] into a [[Result]], using the provided `error` value if the [[Option]] is null.
-     */
-    okOr<E>(error: E): Result<A, E> {
-        return this.match(Ok, () => Err(error));
-    }
+  /**
+   * Convert the [[Option]] into a [[Result]], using the provided `error` value if the [[Option]] is null.
+   */
+  okOr<E>(error: E): Result<A, E> {
+    return this.match(Ok, () => Err(error));
+  }
 
-    /**
-     * Convert the [[Option]] into a [[Result]], calling the provided function to obtain an error value if the [[Option]] is null.
-     */
-    okOrElse<E>(f: () => E): Result<A, E> {
-        return this.match(Ok, () => Err(f()));
-    }
+  /**
+   * Convert the [[Option]] into a [[Result]], calling the provided function to obtain an error value if the [[Option]] is null.
+   */
+  okOrElse<E>(f: () => E): Result<A, E> {
+    return this.match(Ok, () => Err(f()));
+  }
 
-    /**
-     * Convert the [[Option]] into a nullable value of `A`.
-     */
-    unwrap(): A | undefined {
-        return this.option;
-    }
+  /**
+   * Convert the [[Option]] into a nullable value of `A`.
+   */
+  unwrap(): A | undefined {
+    return this.option;
+  }
 
-    /**
-     * Convert the [[Option]] into a value of `A`, using the provided default value if the [[Option]] is null.
-     */
-    unwrapOr(defaultValue: A): A {
-        return this.match(id, constant(defaultValue));
-    }
+  /**
+   * Convert the [[Option]] into a value of `A`, using the provided default value if the [[Option]] is null.
+   */
+  unwrapOr(defaultValue: A): A {
+    return this.match(id, constant(defaultValue));
+  }
 
-    /**
-     * Convert the [[Option]] into a value of `A`, calling the provided function to produce a default value if the [[Option]] is null.
-     */
-    unwrapOrElse(f: () => A): A {
-        return this.match(id, f);
-    }
+  /**
+   * Convert the [[Option]] into a value of `A`, calling the provided function to produce a default value if the [[Option]] is null.
+   */
+  unwrapOrElse(f: () => A): A {
+    return this.match(id, f);
+  }
 }
 
 /**
@@ -176,7 +176,7 @@ export class Option<A> {
  * ```
  */
 export function Some<A>(value: A): Option<A> {
-    return new Option(value);
+  return new Option(value);
 }
 
 /**
@@ -199,93 +199,93 @@ type Err<E> = { tag: "err"; value: E };
  * This is normally used as a return value for operations which can fail: `E` is short for `Error`.
  */
 export class Result<A, E> {
-    private result: Ok<A> | Err<E>;
+  private result: Ok<A> | Err<E>;
 
-    constructor(value: Ok<A> | Err<E>) {
-        this.result = value;
-    }
+  constructor(value: Ok<A> | Err<E>) {
+    this.result = value;
+  }
 
-    /**
-     * Convert a [[Thenable]] returning `A` into a [[Thenable]] returning a [[Result]] of either `A` or the `Error` type.
-     * The new [[Thenable]] always succeeds, reflecting an error condition in the `Result` instead of the failure callback.
-     */
-    static try<A>(m: Thenable<A>): Thenable<Result<A, Error>> {
-        return m.then(Ok, Err);
-    }
+  /**
+   * Convert a [[Thenable]] returning `A` into a [[Thenable]] returning a [[Result]] of either `A` or the `Error` type.
+   * The new [[Thenable]] always succeeds, reflecting an error condition in the `Result` instead of the failure callback.
+   */
+  static try<A>(m: Thenable<A>): Thenable<Result<A, Error>> {
+    return m.then(Ok, Err);
+  }
 
-    /**
-     * In the absence of pattern matching in the language, the `match` function takes two callbacks, one for each possible
-     * state of the [[Result]], and calls the one that matches the actual state.
-     */
-    match<B>(onOk: (value: A) => B, onErr: (value: E) => B): B {
-        if (this.result.tag === "ok") {
-            return onOk(this.result.value);
-        } else {
-            return onErr(this.result.value);
-        }
+  /**
+   * In the absence of pattern matching in the language, the `match` function takes two callbacks, one for each possible
+   * state of the [[Result]], and calls the one that matches the actual state.
+   */
+  match<B>(onOk: (value: A) => B, onErr: (value: E) => B): B {
+    if (this.result.tag === "ok") {
+      return onOk(this.result.value);
+    } else {
+      return onErr(this.result.value);
     }
+  }
 
-    isOk(): boolean {
-        return this.result.tag === "ok";
-    }
+  isOk(): boolean {
+    return this.result.tag === "ok";
+  }
 
-    isErr(): boolean {
-        return this.result.tag === "err";
-    }
+  isErr(): boolean {
+    return this.result.tag === "err";
+  }
 
-    ifOk(onOk: (value: A) => void) {
-        this.match(onOk, constant({}));
-    }
+  ifOk(onOk: (value: A) => void) {
+    this.match(onOk, constant({}));
+  }
 
-    ifErr(onErr: (value: E) => void) {
-        this.match(constant({}), onErr);
-    }
+  ifErr(onErr: (value: E) => void) {
+    this.match(constant({}), onErr);
+  }
 
-    andThen<B>(f: (value: A) => Result<B, E>): Result<B, E> {
-        return this.match(f, Err);
-    }
+  andThen<B>(f: (value: A) => Result<B, E>): Result<B, E> {
+    return this.match(f, Err);
+  }
 
-    orElse<F>(f: (value: E) => Result<A, F>): Result<A, F> {
-        return this.match(Ok, f);
-    }
+  orElse<F>(f: (value: E) => Result<A, F>): Result<A, F> {
+    return this.match(Ok, f);
+  }
 
-    map<B>(f: (value: A) => B): Result<B, E> {
-        return this.andThen((value) => Ok(f(value)));
-    }
+  map<B>(f: (value: A) => B): Result<B, E> {
+    return this.andThen((value) => Ok(f(value)));
+  }
 
-    mapErr<F>(f: (value: E) => F): Result<A, F> {
-        return this.orElse((value) => Err(f(value)));
-    }
+  mapErr<F>(f: (value: E) => F): Result<A, F> {
+    return this.orElse((value) => Err(f(value)));
+  }
 
-    and<B>(result: Result<B, E>): Result<B, E> {
-        return this.andThen(constant(result));
-    }
+  and<B>(result: Result<B, E>): Result<B, E> {
+    return this.andThen(constant(result));
+  }
 
-    or<F>(result: Result<A, F>): Result<A, F> {
-        return this.orElse(constant(result));
-    }
+  or<F>(result: Result<A, F>): Result<A, F> {
+    return this.orElse(constant(result));
+  }
 
-    getOr(defaultValue: A): A {
-        return this.match(id, constant(defaultValue));
-    }
+  getOr(defaultValue: A): A {
+    return this.match(id, constant(defaultValue));
+  }
 
-    getOrElse(f: () => A): A {
-        return this.match(id, f);
-    }
+  getOrElse(f: () => A): A {
+    return this.match(id, f);
+  }
 
-    /**
-     * Converts a [[Result]] into a nullable value of `A`, discarding any error value and returning `undefined` in place of the error.
-     */
-    unwrap(): A | undefined {
-        return this.result.tag === "ok" ? this.result.value : undefined;
-    }
+  /**
+   * Converts a [[Result]] into a nullable value of `A`, discarding any error value and returning `undefined` in place of the error.
+   */
+  unwrap(): A | undefined {
+    return this.result.tag === "ok" ? this.result.value : undefined;
+  }
 
-    /**
-     * Converts a [[Result]] into a nullable value of `E`, discarding any success value and returning `undefined` in place of the `A` value.
-     */
-    unwrapErr(): E | undefined {
-        return this.result.tag === "err" ? this.result.value : undefined;
-    }
+  /**
+   * Converts a [[Result]] into a nullable value of `E`, discarding any success value and returning `undefined` in place of the `A` value.
+   */
+  unwrapErr(): E | undefined {
+    return this.result.tag === "err" ? this.result.value : undefined;
+  }
 }
 
 /**
@@ -296,7 +296,7 @@ export class Result<A, E> {
  * ```
  */
 export function Ok<A = never, E = never>(value: A): Result<A, E> {
-    return new Result<A, E>({ tag: "ok", value });
+  return new Result<A, E>({ tag: "ok", value });
 }
 
 /**
@@ -307,5 +307,5 @@ export function Ok<A = never, E = never>(value: A): Result<A, E> {
  * ```
  */
 export function Err<A = never, E = never>(value: E): Result<A, E> {
-    return new Result<A, E>({ tag: "err", value });
+  return new Result<A, E>({ tag: "err", value });
 }


### PR DESCRIPTION
### Context:
- **Issue 1:** When opening the browser from a notebook, the only option shown is "create this folder". This behavior is due to `vscode.workspace.fs.stat()` failure when a not recognized schema is provided in `Uri` (such as `vscode-notebook-cell`).
**_Before:_**
![image](https://github.com/bodil/vscode-file-browser/assets/47224478/27bf8d54-3277-437e-9b15-2ecf98d1af49)
 **_After:_**
![image](https://github.com/bodil/vscode-file-browser/assets/47224478/faed0fda-d90e-43d6-b39f-8c9f753ecb49)

- **Issue 2:** When opening a notebook file (ipynb) the default openTextDocument + showTextDocument APIs show notebook as json instead of showing cells.
**_Before:_**
![image](https://github.com/bodil/vscode-file-browser/assets/47224478/f392c800-040b-4d56-b73f-f751ebdf5e09)
**_After:_**
![image](https://github.com/bodil/vscode-file-browser/assets/47224478/105feb4c-3361-4db8-bae0-ff5130a544ed)
   

### Related issues:
- https://github.com/bodil/vscode-file-browser/issues/52